### PR TITLE
Use argparser version 0.1 instead of 0.3 which was just released.

### DIFF
--- a/scripts/install_R_packages.R
+++ b/scripts/install_R_packages.R
@@ -1,6 +1,10 @@
 source("http://bioconductor.org/biocLite.R")
 biocLite("DNAcopy")
-dependencies = c("argparser", "naturalsort")
+argparserurl="http://cran.r-project.org/src/contrib/Archive/argparser/argparser_0.1.tar.gz"
+if (length(setdiff("argparser", rownames(installed.packages()))) > 0) {
+  install.packages(argparserurl, repos=NULL, type="source")
+}
+dependencies = c("naturalsort")
 if (length(setdiff(dependencies, rownames(installed.packages()))) > 0) {
   install.packages(setdiff(dependencies, rownames(installed.packages())), repos="http://cran.cnr.Berkeley.edu")
 }


### PR DESCRIPTION
I'll make a new issue to update to argparser 0.3 and use whatever the new correct syntax is.
