### PR TITLE
Updated coveralls badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/broadinstitute/gatk-protected.svg?branch=master)](https://travis-ci.org/broadinstitute/gatk-protected)
-[![Coverage Status](https://coveralls.io/repos/broadinstitute/gatk-protected/badge.svg?branch=master&t=fjUaFR)](https://coveralls.io/r/broadinstitute/gatk-protected?branch=master)
+[![Coverage Status](https://coveralls.io/repos/broadinstitute/gatk-protected/badge.svg?branch=master&service=github)](https://coveralls.io/github/broadinstitute/gatk-protected?branch=master)
 
 GATK4-Protected (codename Hellbender-protected)
 ===============================================


### PR DESCRIPTION
Looks like the repo wasn't activated on coveralls after the name change, should be fixed now.