### PR TITLE
Added calculation of MCMC credible intervals in PosteriorSummary using mllib kernel density estimation.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureWalker.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.engine;
 
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
-import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/ACNVModeledSegment.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/ACNVModeledSegment.java
@@ -5,7 +5,7 @@ import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.mcmc.PosteriorSummary;
 
 /**
- * Represents a segment with copy-ratio segment mean and minor allele fraction posterior summaries.
+ * Represents a segment with copy-ratio--segment-mean and minor-allele-fraction posterior summaries.
  *
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetBaseCallCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetBaseCallCoverage.java
@@ -30,7 +30,10 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.IntBinaryOperator;
 import java.util.function.ToIntFunction;
-import java.util.stream.*;
+import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
+import java.util.stream.LongStream;
+import java.util.stream.StreamSupport;
 
 /**
  * Calculates the coverage for each target at each input sample.

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/Case2PoNTargetMapper.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/Case2PoNTargetMapper.java
@@ -3,11 +3,9 @@ package org.broadinstitute.hellbender.tools.exome;
 import org.apache.commons.collections4.list.SetUniqueList;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.hdf5.PoN;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CreatePanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CreatePanelOfNormals.java
@@ -9,12 +9,17 @@ import org.broadinstitute.hellbender.cmdline.programgroups.CopyNumberProgramGrou
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SparkToggleCommandLineProgram;
 import org.broadinstitute.hellbender.utils.Utils;
-import org.broadinstitute.hellbender.utils.hdf5.*;
+import org.broadinstitute.hellbender.utils.hdf5.HDF5File;
+import org.broadinstitute.hellbender.utils.hdf5.HDF5PoN;
+import org.broadinstitute.hellbender.utils.hdf5.HDF5PoNCreator;
+import org.broadinstitute.hellbender.utils.hdf5.PoN;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalInt;
 
 /**
  * Tool to create a panel of normals (PoN) given a collection of read-counts

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/PoNIssueDetector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/PoNIssueDetector.java
@@ -1,11 +1,7 @@
 package org.broadinstitute.hellbender.tools.exome;
 
-import akka.io.Udp;
-import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
-import com.google.api.services.genomics.model.Read;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Doubles;
-import org.apache.commons.collections.map.HashedMap;
-import org.apache.commons.collections4.list.SetUniqueList;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.linear.RealVector;
 import org.apache.commons.math3.stat.descriptive.rank.Median;
@@ -14,16 +10,15 @@ import org.apache.logging.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.hdf5.HDF5File;
 import org.broadinstitute.hellbender.utils.hdf5.HDF5PoN;
 import org.broadinstitute.hellbender.utils.hdf5.PoN;
-import org.broadinstitute.hellbender.utils.io.IOUtils;
-import org.broadinstitute.hellbender.utils.param.ParamUtils;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/ReductionResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/ReductionResult.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.hellbender.tools.exome;
 
-import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.math3.linear.RealMatrix;
 
 /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/SegmentTableColumns.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/SegmentTableColumns.java
@@ -12,11 +12,12 @@ enum SegmentTableColumns {
     SAMPLE("Sample"), CONTIG("Chromosome"), START("Start"), END("End"),
     NUM_PROBES("Num_Probes"), MEAN("Segment_Mean"), SD("Segment_Std"), CALL("Segment_Call"),
     NUM_TARGETS("Num_Targets"), NUM_SNPS("Num_SNPs"),
-    SEGMENT_MEAN_POSTERIOR_MEAN("Segment_Mean_Post_Mean"),
-    SEGMENT_MEAN_POSTERIOR_STANDARD_DEVIATION("Segment_Mean_Post_Std"),
-    MINOR_ALLELE_FRACTION_POSTERIOR_MEAN("MAF_Post_Mean"),
-    MINOR_ALLELE_FRACTION_POSTERIOR_STANDARD_DEVIATION("MAF_Post_Std"),
-
+    SEGMENT_MEAN_POSTERIOR_MODE("Segment_Mean_Post_Mode"),
+    SEGMENT_MEAN_POSTERIOR_LOWER("Segment_Mean_Post_Lo"),
+    SEGMENT_MEAN_POSTERIOR_UPPER("Segment_Mean_Post_Hi"),
+    MINOR_ALLELE_FRACTION_POSTERIOR_MODE("MAF_Post_Mode"),
+    MINOR_ALLELE_FRACTION_POSTERIOR_LOWER("MAF_Post_Lo"),
+    MINOR_ALLELE_FRACTION_POSTERIOR_UPPER("MAF_Post_Hi"),
 
     // Germline Segments quality scores:
 
@@ -78,8 +79,9 @@ enum SegmentTableColumns {
 
     private static final SegmentTableColumns[] ACNV_MODELED_SEGMENT_ENUM_ARRAY =
             new SegmentTableColumns[]{SAMPLE, CONTIG, START, END, NUM_TARGETS, NUM_SNPS,
-                    SEGMENT_MEAN_POSTERIOR_MEAN, SEGMENT_MEAN_POSTERIOR_STANDARD_DEVIATION,
-                    MINOR_ALLELE_FRACTION_POSTERIOR_MEAN, MINOR_ALLELE_FRACTION_POSTERIOR_STANDARD_DEVIATION};
+                    SEGMENT_MEAN_POSTERIOR_MODE, SEGMENT_MEAN_POSTERIOR_LOWER, SEGMENT_MEAN_POSTERIOR_UPPER,
+                    MINOR_ALLELE_FRACTION_POSTERIOR_MODE, MINOR_ALLELE_FRACTION_POSTERIOR_LOWER,
+                    MINOR_ALLELE_FRACTION_POSTERIOR_UPPER};
 
     private static final SegmentTableColumns[] GERMLINE_CALL_OUTPUT_COLUMNS =
             new SegmentTableColumns[]{

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/SegmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/SegmentUtils.java
@@ -278,10 +278,15 @@ public final class SegmentUtils {
                 (segment, dataLine) ->
                         dataLine.append(segment.getContig()).append(segment.getStart(), segment.getEnd())
                                 .append(targets.targetCount(segment)).append(snps.targetCount(segment))
-                                .append(String.format("%6.4f", segment.getSegmentMeanPosteriorSummary().mean()))
-                                .append(String.format("%6.4f", segment.getSegmentMeanPosteriorSummary().standardDeviation()))
-                                .append(String.format("%6.4f", segment.getMinorAlleleFractionPosteriorSummary().mean()))
-                                .append(String.format("%6.4f", segment.getMinorAlleleFractionPosteriorSummary().standardDeviation())));
+                                .append(String.format("%6.4f", segment.getSegmentMeanPosteriorSummary().center()))
+                                .append(String.format("%6.4f", segment.getSegmentMeanPosteriorSummary().lower()))
+                                .append(String.format("%6.4f", segment.getSegmentMeanPosteriorSummary().upper()))
+                                .append(String.format("%6.4f", segment.getMinorAlleleFractionPosteriorSummary().center())
+                                        .replaceAll("\\s+", ""))
+                                .append(String.format("%6.4f", segment.getMinorAlleleFractionPosteriorSummary().lower())
+                                        .replaceAll("\\s+", ""))
+                                .append(String.format("%6.4f", segment.getMinorAlleleFractionPosteriorSummary().upper())
+                                        .replaceAll("\\s+","")));
     }
 
     /*===============================================================================================================*

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/allelefraction/AlleleFractionInitializer.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/allelefraction/AlleleFractionInitializer.java
@@ -72,14 +72,14 @@ public final class AlleleFractionInitializer {
         double previousIterationLogLikelihood;
         double nextIterationLogLikelihood = Double.NEGATIVE_INFINITY;
         int iteration = 1;
-        logger.info(String.format("Initializing allele fraction model.  Iterating until log likelihood converges to within %.3f.%n",
+        logger.info(String.format("Initializing allele fraction model.  Iterating until log likelihood converges to within %.3f.",
                 LOG_LIKELIHOOD_CONVERGENCE_THRESHOLD));
         do {
             previousIterationLogLikelihood = nextIterationLogLikelihood;
             state = new AlleleFractionState(estimateMeanBias(data), estimateBiasVariance(data),
                     estimateOutlierProbability(data), estimateMinorFractions(data));
             nextIterationLogLikelihood = AlleleFractionModeller.logLikelihood(state, data);
-            logger.info(String.format("Iteration %d, model log likelihood = %.3f.%n", iteration, nextIterationLogLikelihood));
+            logger.info(String.format("Iteration %d, model log likelihood = %.3f.", iteration, nextIterationLogLikelihood));
             iteration++;
         } while (iteration < MAX_ITERATIONS &&
                 nextIterationLogLikelihood - previousIterationLogLikelihood > LOG_LIKELIHOOD_CONVERGENCE_THRESHOLD);

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/hmm/CopyNumberTriStateHiddenMarkovModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/hmm/CopyNumberTriStateHiddenMarkovModel.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.tools.exome.hmm;
 
-import com.google.cloud.dataflow.sdk.repackaged.com.google.common.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.math.DoubleRange;
 import org.apache.commons.math3.distribution.NormalDistribution;
 import org.broadinstitute.hellbender.tools.exome.Target;

--- a/src/main/java/org/broadinstitute/hellbender/utils/SparkToggleCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SparkToggleCommandLineProgram.java
@@ -35,7 +35,7 @@ public abstract class SparkToggleCommandLineProgram extends SparkCommandLineProg
             logger.info("Spark disabled.  sparkMaster option (" + sparkArgs.getSparkMaster() + ") ignored.");
         }
 
-        try{
+        try {
             runPipeline(ctx);
             return null;
         } finally {

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5File.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5File.java
@@ -1,13 +1,11 @@
 package org.broadinstitute.hellbender.utils.hdf5;
 
-import com.google.cloud.dataflow.sdk.repackaged.com.google.common.collect.ObjectArrays;
 import ncsa.hdf.hdf5lib.H5;
 import ncsa.hdf.hdf5lib.HDF5Constants;
 import ncsa.hdf.hdf5lib.exceptions.HDF5Exception;
 import ncsa.hdf.hdf5lib.exceptions.HDF5LibraryException;
 import ncsa.hdf.hdf5lib.structs.H5G_info_t;
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.exceptions.GATKException;

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoN.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoN.java
@@ -1,12 +1,11 @@
 package org.broadinstitute.hellbender.utils.hdf5;
 
-import com.google.cloud.dataflow.sdk.repackaged.com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap;
 import htsjdk.samtools.util.Lazy;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.tools.exome.Target;
-import org.broadinstitute.hellbender.tools.exome.TargetCoverageUtils;
 import org.broadinstitute.hellbender.tools.exome.TargetTableColumns;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoNCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoNCreator.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.utils.hdf5;
 
-import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Doubles;
 import org.apache.commons.collections4.list.SetUniqueList;

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/PoN.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/PoN.java
@@ -3,16 +3,10 @@ package org.broadinstitute.hellbender.utils.hdf5;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.DefaultRealMatrixChangingVisitor;
 import org.apache.commons.math3.linear.RealMatrix;
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.broadcast.Broadcast;
 import org.broadinstitute.hellbender.tools.exome.Target;
-import org.apache.commons.math3.linear.RealVector;
 import org.broadinstitute.hellbender.utils.Utils;
 
-import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.IntStream;
 
 /**
  * Panel of Normal data structure.

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/RamPoN.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/RamPoN.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.utils.hdf5;
 
 import org.apache.commons.math3.linear.RealMatrix;
-import org.broadinstitute.hellbender.tools.exome.CreatePanelOfNormals;
 import org.broadinstitute.hellbender.tools.exome.ReductionResult;
 import org.broadinstitute.hellbender.tools.exome.Target;
 import org.broadinstitute.hellbender.utils.SimpleInterval;

--- a/src/main/java/org/broadinstitute/hellbender/utils/mcmc/PosteriorSummary.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/mcmc/PosteriorSummary.java
@@ -1,28 +1,140 @@
 package org.broadinstitute.hellbender.utils.mcmc;
 
+import com.google.common.primitives.Doubles;
+import org.apache.commons.math3.optim.MaxEval;
+import org.apache.commons.math3.optim.nonlinear.scalar.GoalType;
+import org.apache.commons.math3.optim.univariate.BrentOptimizer;
+import org.apache.commons.math3.optim.univariate.SearchInterval;
+import org.apache.commons.math3.optim.univariate.UnivariateObjectiveFunction;
+import org.apache.commons.math3.stat.descriptive.moment.Mean;
+import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.mllib.stat.KernelDensity;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Represents the mean and standard deviation of the posterior of a univariate model parameter.
+ * Represents central tendency and upper/lower credible-interval bounds of the posterior of a univariate model parameter.
  *
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class PosteriorSummary {
-    private final double mean;
-    private final double standardDeviation;
+    public static final double SILVERMANS_RULE_CONSTANT = 1.06;
+    public static final double SILVERMANS_RULE_EXPONENT = -0.2;
 
-    public PosteriorSummary(final double mean, final double standardDeviation) {
-        this.mean = mean;
-        this.standardDeviation = standardDeviation;
+    //constants for Brent optimization
+    private static final MaxEval BRENT_MAX_EVAL = new MaxEval(100);
+    private static final double RELATIVE_TOLERANCE = 0.01;
+
+    private final double center;
+    private final double lower;
+    private final double upper;
+
+    /**
+     * Constructs a PosteriorSummary with given central tendency and upper/lower credible-interval bounds.
+     * @param center    central tendency
+     * @param lower     lower credible-interval bound
+     * @param upper     upper credible-interval bound
+     */
+    public PosteriorSummary(final double center, final double lower, final double upper) {
+        this.center = center;
+        this.lower = lower;
+        this.upper = upper;
     }
 
-    public PosteriorSummary(final PosteriorSummary summary) {
-        this(summary.mean(), summary.standardDeviation());
+    public double center() {   return center; }
+    public double lower() {     return lower;   }
+    public double upper() {     return upper;   }
+
+    /**
+     * Given a list of posterior samples, returns a PosteriorSummary with central tendency given by the posterior mode
+     * (which is estimated using mllib kernel density estimation in {@link KernelDensity},
+     * see {@link PosteriorSummary#calculatePosteriorMode(List, JavaSparkContext)}) and lower/upper credible-interval
+     * bounds given by the (1-{@code alpha}) highest-posterior-density interval (i.e., the narrowest interval
+     * that contains (1-{@code alpha}) of the samples).  Unimodality is assumed.  If the samples contain
+     * {@link Double#NaN}, a {@link PosteriorSummary} with
+     * {@link PosteriorSummary#center}, {@link PosteriorSummary#lower}, and {@link PosteriorSummary#upper}
+     * all set to {@link Double#NaN} will be returned.
+     * @param samples   posterior samples, cannot be {@code null} and number of samples must be greater than 0
+     * @param alpha     credible-interval alpha, must be in (0, 1)
+     * @param ctx       {@link JavaSparkContext} used by {@link KernelDensity} for mllib kernel density estimation
+     */
+    public static PosteriorSummary calculateHighestPosteriorDensitySummary(final List<Double> samples,
+                                                                           final double alpha,
+                                                                           final JavaSparkContext ctx) {
+        Utils.nonNull(samples);
+        Utils.validateArg(samples.size() > 0, "Number of samples must be greater than zero.");
+        Utils.validateArg(0 < alpha && alpha < 1, "Alpha must be in (0, 1).");
+
+        final double central = calculatePosteriorMode(samples, ctx);
+
+        //if samples contain NaN, return NaN for all posterior-summary values
+        if (Double.isNaN(central)) {
+            return new PosteriorSummary(Double.NaN, Double.NaN, Double.NaN);
+        }
+
+        //find highest-posterior-density interval using simple Chen & Shao 1998 procedure
+        final List<Double> sortedSamples = new ArrayList<>(samples);
+        Collections.sort(sortedSamples);
+        final int n = sortedSamples.size();
+        double lower = sortedSamples.get(0);
+        double upper = sortedSamples.get(n - 1);
+        double minIntervalWidth = sortedSamples.get(n - 1) - sortedSamples.get(0);
+        final int numSamplesInInterval = (int) Math.floor((1 - alpha) * n);
+        for (int i = 0; i < n - numSamplesInInterval; i++) {
+            final double intervalWidth = sortedSamples.get(i + numSamplesInInterval) - sortedSamples.get(i);
+            if (intervalWidth < minIntervalWidth) {
+                minIntervalWidth = intervalWidth;
+                lower = sortedSamples.get(i);
+                upper = sortedSamples.get(i + numSamplesInInterval);
+            }
+        }
+
+        return new PosteriorSummary(central, lower, upper);
     }
 
-    public double mean() {
-        return mean;
-    }
+    /**
+     * Given a list of posterior samples, returns an estimate of the posterior mode (using
+     * mllib kernel density estimation in {@link KernelDensity} and {@link BrentOptimizer}).
+     * Note that estimate may be poor if number of samples is small (resulting in poor kernel density estimation),
+     * or if posterior is not unimodal (or is sufficiently pathological otherwise). If the samples contain
+     * {@link Double#NaN}, {@link Double#NaN} will be returned.
+     * @param samples   posterior samples, cannot be {@code null} and number of samples must be greater than 0
+     * @param ctx       {@link JavaSparkContext} used by {@link KernelDensity} for mllib kernel density estimation
+     */
+    public static double calculatePosteriorMode(final List<Double> samples, final JavaSparkContext ctx) {
+        Utils.nonNull(samples);
+        Utils.validateArg(samples.size() > 0, "Number of samples must be greater than zero.");
 
-    public double standardDeviation() {
-        return standardDeviation;
+        //calculate sample min, max, mean, and standard deviation
+        final double sampleMin = Collections.min(samples);
+        final double sampleMax = Collections.max(samples);
+        final double sampleMean = new Mean().evaluate(Doubles.toArray(samples));
+        final double sampleStandardDeviation = new StandardDeviation().evaluate(Doubles.toArray(samples));
+
+        //if samples are all the same or contain NaN, can simply return mean
+        if (sampleStandardDeviation == 0. || Double.isNaN(sampleMean)) {
+            return sampleMean;
+        }
+
+        //use Silverman's rule to set bandwidth for kernel density estimation from sample standard deviation
+        //see https://en.wikipedia.org/wiki/Kernel_density_estimation#Practical_estimation_of_the_bandwidth
+        final double bandwidth =
+                SILVERMANS_RULE_CONSTANT * sampleStandardDeviation * Math.pow(samples.size(), SILVERMANS_RULE_EXPONENT);
+
+        //use kernel density estimation to approximate posterior from samples
+        final KernelDensity pdf = new KernelDensity().setSample(ctx.parallelize(samples, 1)).setBandwidth(bandwidth);
+
+        //use Brent optimization to find mode (i.e., maximum) of kernel-density-estimated posterior
+        final BrentOptimizer optimizer =
+                new BrentOptimizer(RELATIVE_TOLERANCE, RELATIVE_TOLERANCE * (sampleMax - sampleMin));
+        final UnivariateObjectiveFunction objective =
+                new UnivariateObjectiveFunction(f -> pdf.estimate(new double[] {f})[0]);
+        //search for mode within sample range, start near sample mean
+        final SearchInterval searchInterval = new SearchInterval(sampleMin, sampleMax, sampleMean);
+        return optimizer.optimize(objective, GoalType.MAXIMIZE, searchInterval, BRENT_MAX_EVAL).getPoint();
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/param/ParamUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/param/ParamUtils.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.utils.param;
 
-import com.google.cloud.dataflow.sdk.repackaged.com.google.common.primitives.Doubles;
+import com.google.common.primitives.Doubles;
 import org.apache.commons.lang.math.DoubleRange;
 import org.apache.commons.math3.exception.NotFiniteNumberException;
 import org.apache.commons.math3.util.MathUtils;

--- a/src/main/java/org/broadinstitute/hellbender/utils/segmenter/RCBSSegmenter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/segmenter/RCBSSegmenter.java
@@ -2,8 +2,6 @@ package org.broadinstitute.hellbender.utils.segmenter;
 
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.R.RScriptExecutor;
-import org.broadinstitute.hellbender.utils.Utils;
-import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.io.Resource;
 import org.broadinstitute.hellbender.utils.param.ParamUtils;
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/svd/OjAlgoSingularValueDecomposer.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/svd/OjAlgoSingularValueDecomposer.java
@@ -5,7 +5,6 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.utils.Utils;
-import org.ojalgo.OjAlgoUtils;
 import org.ojalgo.matrix.decomposition.SingularValue;
 import org.ojalgo.matrix.store.PhysicalStore;
 import org.ojalgo.matrix.store.PrimitiveDenseStore;

--- a/src/main/java/org/broadinstitute/hellbender/utils/svd/SparkSingularValueDecomposer.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/svd/SparkSingularValueDecomposer.java
@@ -1,10 +1,8 @@
 package org.broadinstitute.hellbender.utils.svd;
 
-import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.mllib.linalg.*;
 import org.apache.spark.mllib.linalg.distributed.RowMatrix;
@@ -12,7 +10,6 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.spark.SparkConverter;
 
 import java.util.Arrays;
-import java.util.LinkedList;
 
 class SparkSingularValueDecomposer {
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/CreatePanelOfNormalsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/CreatePanelOfNormalsIntegrationTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.tools.exome;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.math.IntRange;
-import org.apache.commons.math3.linear.RealMatrix;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -13,7 +12,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.IntStream;
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/DecomposeSingularValuesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/DecomposeSingularValuesIntegrationTest.java
@@ -1,9 +1,6 @@
 package org.broadinstitute.hellbender.tools.exome;
 
 
-import au.com.bytecode.opencsv.CSVWriter;
-import com.opencsv.CSVReader;
-import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.DiagonalMatrix;
 import org.apache.commons.math3.linear.MatrixUtils;
 import org.apache.commons.math3.linear.RealMatrix;
@@ -17,10 +14,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class DecomposeSingularValuesIntegrationTest extends CommandLineProgramTest {

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/PlotSegmentedCopyRatioIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/PlotSegmentedCopyRatioIntegrationTest.java
@@ -20,7 +20,6 @@ public class PlotSegmentedCopyRatioIntegrationTest extends CommandLineProgramTes
         final File SEG_FILE = new File("src/test/resources/org/broadinstitute/hellbender/utils/plotter/HCC1143.seg");
         final String sampleName = "HCC1143";
         File tDir = IOUtils.tempDir("Test", "Plotting");
-        System.out.println(tDir);
         CopyRatioSegmentedPlotter.writeSegmentedCopyRatioPlot(sampleName, TN_FILE.getAbsolutePath(),
                 PRE_TN_FILE.getAbsolutePath(), SEG_FILE.getAbsolutePath(), tDir.getAbsolutePath() + "/", true, false);
         final String[] arguments = {
@@ -52,7 +51,6 @@ public class PlotSegmentedCopyRatioIntegrationTest extends CommandLineProgramTes
         final File SEG_FILE = new File("src/test/resources/org/broadinstitute/hellbender/utils/plotter/HCC1143.seg");
         final String sampleName = "HCC1143";
         File tDir = IOUtils.tempDir("Test", "Plotting");
-        System.out.println(tDir);
         CopyRatioSegmentedPlotter.writeSegmentedCopyRatioPlot(sampleName, TN_FILE.getAbsolutePath(),
                 PRE_TN_FILE.getAbsolutePath(), SEG_FILE.getAbsolutePath(), tDir.getAbsolutePath() + "/", true, false);
         final String[] arguments = {

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/PoNIssueDetectorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/PoNIssueDetectorUnitTest.java
@@ -10,7 +10,9 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class PoNIssueDetectorUnitTest extends BaseTest {
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/SNPSegmenterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/SNPSegmenterUnitTest.java
@@ -6,9 +6,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Unit tests for {@link SNPSegmenter}.

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/allelefraction/AlleleFractionSimulatedData.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/allelefraction/AlleleFractionSimulatedData.java
@@ -1,12 +1,9 @@
 package org.broadinstitute.hellbender.tools.exome.allelefraction;
 
-import breeze.stats.distributions.Poisson;
-import htsjdk.samtools.util.Interval;
 import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.apache.commons.math3.distribution.GammaDistribution;
 import org.apache.commons.math3.distribution.PoissonDistribution;
 import org.apache.commons.math3.distribution.UniformRealDistribution;
-import org.apache.commons.math3.random.RandomGenerator;
 import org.apache.commons.math3.random.Well19937a;
 import org.broadinstitute.hellbender.tools.exome.AllelicCount;
 import org.broadinstitute.hellbender.tools.exome.Genome;

--- a/src/test/java/org/broadinstitute/hellbender/utils/hdf5/PoNTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/hdf5/PoNTestUtils.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.utils.hdf5;
 
 import au.com.bytecode.opencsv.CSVWriter;
 import com.opencsv.CSVReader;
-import htsjdk.samtools.util.StringUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;

--- a/src/test/java/org/broadinstitute/hellbender/utils/mcmc/AbstractParameterizedStateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/mcmc/AbstractParameterizedStateUnitTest.java
@@ -13,7 +13,7 @@ import java.util.stream.IntStream;
  *
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
-public final class AbstractParameterizedStateTest {
+public final class AbstractParameterizedStateUnitTest {
     private final class TestSubstate extends AbstractParameterizedState {
         private static final String SUBSTATE_PARAMETER_PREFIX = "theta";
 

--- a/src/test/java/org/broadinstitute/hellbender/utils/mcmc/ParameterizedModelUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/mcmc/ParameterizedModelUnitTest.java
@@ -11,7 +11,7 @@ import java.util.List;
  *
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
-public final class ParameterizedModelTest {
+public final class ParameterizedModelUnitTest {
     private static final ParameterizedState SIMPLE_STATE =
             new ParameterizedState(Collections.singletonList(new Parameter<>("parameter", 1.)));
     private static final TestDataCollection EMPTY_DATA =

--- a/src/test/java/org/broadinstitute/hellbender/utils/mcmc/PosteriorSummaryUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/mcmc/PosteriorSummaryUnitTest.java
@@ -1,0 +1,103 @@
+package org.broadinstitute.hellbender.utils.mcmc;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.math3.distribution.BetaDistribution;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.apache.commons.math3.random.RandomGenerator;
+import org.apache.commons.math3.random.RandomGeneratorFactory;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for {@link PosteriorSummary}.  Tests that posterior mode and highest-posterior-density credible interval
+ * are recovered for samples drawn from various posterior distributions.
+ *
+ * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
+ */
+public final class PosteriorSummaryUnitTest extends BaseTest {
+    private static final int RANDOM_SEED = 42;
+    private static final RandomGenerator rng = RandomGeneratorFactory.createRandomGenerator(new Random(RANDOM_SEED));
+
+    private static final List<Double> normalSamples = toList(new NormalDistribution(rng, 10., 1).sample(100));
+    private static final List<Double> normalSamplesSmall = toList(new NormalDistribution(rng, 10., 1).sample(10));
+    private static final List<Double> normalSamplesScaled = toList(new NormalDistribution(rng, 10., 0.01).sample(100));
+
+    private static final List<Double> betaSamples = toList(new BetaDistribution(rng, 10, 4).sample(1000));
+    private static final List<Double> betaSamplesEdgeMode = toList(new BetaDistribution(rng, 10, 1).sample(1000));
+    private static final List<Double> betaSamplesMAF = Arrays.stream(ArrayUtils.addAll(
+            new BetaDistribution(rng, 10, 6).sample(1000),
+            new BetaDistribution(rng, 6, 10).sample(1000)))
+            .boxed().filter(d -> d <= 0.5).collect(Collectors.toList());    //mimics ACNV minor-allele-fraction posterior
+
+    private static final List<Double> identicalSamples = Collections.nCopies(1000, 1.);
+    private static final List<Double> withNaNSamples = toList(new double[]{Double.NEGATIVE_INFINITY, 0., 1.});
+
+    @DataProvider(name = "dataKernelDensityEstimation")
+    public Object[][] dataHPD() {
+        return new Object[][]{
+                //samples, alpha, relative error tolerance, expected (calculated using Mathematica for Beta tests)
+                {normalSamples, 0.32, 0.05, new PosteriorSummary(10., 9., 11.)},
+                {normalSamples, 0.05, 0.05, new PosteriorSummary(10., 8., 12.)},
+                {normalSamplesSmall, 0.32, 0.15, new PosteriorSummary(10., 9., 11.)},
+                {normalSamplesSmall, 0.05, 0.15, new PosteriorSummary(10., 8., 12.)},
+                {normalSamplesScaled, 0.32, 0.05, new PosteriorSummary(10., 9.99, 10.01)},
+                {normalSamplesScaled, 0.05, 0.05, new PosteriorSummary(10., 9.98, 10.02)},
+                {betaSamples, 0.32, 0.05, new PosteriorSummary(0.75, 0.621, 0.854)},
+                {betaSamples, 0.05, 0.05, new PosteriorSummary(0.75, 0.487, 0.925)},
+                {betaSamplesEdgeMode, 0.32, 0.05, new PosteriorSummary(1.0, 0.8923, 1.)},
+                {betaSamplesEdgeMode, 0.05, 0.05, new PosteriorSummary(1.0, 0.7411, 1.)},
+                {betaSamplesMAF, 0.32, 0.05, new PosteriorSummary(0.415, 0.312, 0.5)},
+                {betaSamplesMAF, 0.05, 0.05, new PosteriorSummary(0.415, 0.191, 0.5)},
+                {identicalSamples, 0.32, 0.01, new PosteriorSummary(1., 1., 1.)},
+                {withNaNSamples, 0.32, 0.01, new PosteriorSummary(Double.NaN, Double.NaN, Double.NaN)},
+        };
+    }
+
+    @Test(dataProvider = "dataKernelDensityEstimation")
+    public void testCalculateHighestPosteriorDensitySummary(final List<Double> samples,
+                                                            final double credibleIntervalAlpha,
+                                                            final double relativeError,
+                                                            final PosteriorSummary expected) {
+        final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        final PosteriorSummary result =
+                PosteriorSummary.calculateHighestPosteriorDensitySummary(samples, credibleIntervalAlpha, ctx);
+        assertEquals(result, expected, relativeError);
+    }
+
+    @Test(dataProvider = "dataKernelDensityEstimation")
+    public void testCalculatePosteriorMode(final List<Double> samples,
+                                           final double credibleIntervalAlpha,
+                                           final double relativeError,
+                                           final PosteriorSummary expected) {
+        final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        final double result = PosteriorSummary.calculatePosteriorMode(samples, ctx);
+        Assert.assertTrue(withinRelativeError(result, expected.center(), relativeError));
+
+    }
+
+    private static boolean withinRelativeError(final double x, final double xTrue, final double relativeError) {
+        if (Double.isNaN(xTrue)) {
+            return Double.isNaN(x);
+        }
+        return Math.abs(x - xTrue) < Math.abs(relativeError * xTrue);
+    }
+
+    private static List<Double> toList(double[] array) {
+        return Arrays.stream(array).boxed().collect(Collectors.toList());   }
+
+    private static void assertEquals(final PosteriorSummary result, final PosteriorSummary expected, final double relativeError) {
+        Assert.assertTrue(withinRelativeError(result.center(), expected.center(), relativeError));
+        Assert.assertTrue(withinRelativeError(result.lower(), expected.lower(), relativeError));
+        Assert.assertTrue(withinRelativeError(result.upper(), expected.upper(), relativeError));
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/plotter/AlleleFractionPlotterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/plotter/AlleleFractionPlotterTest.java
@@ -15,7 +15,6 @@ public class AlleleFractionPlotterTest extends BaseTest {
         final File SEGMENTS_FILE = new File("src/test/resources/org/broadinstitute/hellbender/utils/plotter/allelic.seg");
         String sampleName = "HCC1143";
         File tDir = IOUtils.tempDir("Test", "Plotting");
-        System.out.println(tDir);
         AlleleFractionSegmentedPlotter.writeSegmentedAlleleFractionPlot(sampleName, SNP_COUNTS_FILE.getAbsolutePath(),
                 SEGMENTS_FILE.getAbsolutePath(), tDir.getAbsolutePath()+"/", false);
         Assert.assertTrue(new File(tDir + "/" + sampleName + "_FullGenome.png").exists());
@@ -28,7 +27,6 @@ public class AlleleFractionPlotterTest extends BaseTest {
         final File SEGMENTS_FILE = new File("src/test/resources/org/broadinstitute/hellbender/utils/plotter/allelic.seg");
         String sampleName = "HCC1143";
         File tDir = IOUtils.tempDir("Test", "Plotting");
-        System.out.println(tDir);
         AlleleFractionSegmentedPlotter.writeSegmentedAlleleFractionPlot(sampleName, SNP_COUNTS_FILE.getAbsolutePath(),
                 SEGMENTS_FILE.getAbsolutePath(), tDir.getAbsolutePath()+"/", true);
         Assert.assertTrue(new File(tDir + "/" + sampleName + "_FullGenome.png").exists());

--- a/src/test/java/org/broadinstitute/hellbender/utils/plotter/TangentPlotterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/plotter/TangentPlotterTest.java
@@ -16,7 +16,6 @@ public class TangentPlotterTest extends BaseTest {
         final File SEG_FILE = new File("src/test/resources/org/broadinstitute/hellbender/utils/segmenter/output/HCC1143_reduced_result.seg");
         String sampleName = "HCC1143";
         File tDir = IOUtils.tempDir("Test", "Plotting");
-        System.out.println(tDir);
         CopyRatioSegmentedPlotter.writeSegmentedCopyRatioPlot(sampleName, INPUT_FILE.getAbsolutePath(),
                 INPUT_FILE.getAbsolutePath(), SEG_FILE.getAbsolutePath(), tDir.getAbsolutePath()+"/", false, false);
         Assert.assertTrue(new File(tDir + "/" + sampleName + "_FullGenome.png").exists());
@@ -39,7 +38,6 @@ public class TangentPlotterTest extends BaseTest {
         final File SEG_FILE = new File("src/test/resources/org/broadinstitute/hellbender/utils/segmenter/output/HCC1143_reduced_result.seg");
         String sampleName = "HCC1143";
         File tDir = IOUtils.tempDir("Test", "Plotting");
-        System.out.println(tDir);
         CopyRatioSegmentedPlotter.writeSegmentedCopyRatioPlot(sampleName, INPUT_FILE.getAbsolutePath(),
                 INPUT_FILE.getAbsolutePath(), SEG_FILE.getAbsolutePath(), tDir.getAbsolutePath()+"/", false, true);
         Assert.assertTrue(new File(tDir + "/" + sampleName + "_FullGenome.png").exists());

--- a/src/test/resources/org/broadinstitute/hellbender/utils/plotter/HCC1143.preTN.tsv
+++ b/src/test/resources/org/broadinstitute/hellbender/utils/plotter/HCC1143.preTN.tsv
@@ -1,6 +1,3 @@
-#fileFormat = tsv
-#commandLine = org.broadinstitute.hellbender.tools.exome.NormalizeSomaticReadCounts  --input /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/cov/HCC1143-coverage.tsv --targets /Users/aaronc/Documents/recapseg-hb-eval/whole_exome_agilent_1.1_refseq_plus_3_boosters.Homo_sapiens_assembly19.targets_germline_copy_number_variants_X_Y_removed.bed --panelOfNormals /Users/aaronc/Documents/recapseg-hb-eval/Mega_PoN_v2.6.pon --factorNormalizedOutput /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/tumor_pcov/HCC1143.fnt.tsv --output /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/tumor_pcov/HCC1143.tn.tsv --betaHatsOutput /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/tumor_pcov/HCC1143.betaHats.tsv --preTangentNormalizationOutput /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/tumor_pcov/HCC1143.preTN.tsv  --help false --version false --verbosity INFO --QUIET false
-#title = Pre tangent normalized coverage profile
 name	contig	start	stop	HCC1143
 target_1_None	1	30366	30503	-0.5672720283943717
 target_2_None	1	69089	70010	-0.2298798434421816

--- a/src/test/resources/org/broadinstitute/hellbender/utils/plotter/HCC1143.tn.tsv
+++ b/src/test/resources/org/broadinstitute/hellbender/utils/plotter/HCC1143.tn.tsv
@@ -1,6 +1,3 @@
-#fileFormat = tsv
-#commandLine = org.broadinstitute.hellbender.tools.exome.NormalizeSomaticReadCounts  --input /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/cov/HCC1143-coverage.tsv --targets /Users/aaronc/Documents/recapseg-hb-eval/whole_exome_agilent_1.1_refseq_plus_3_boosters.Homo_sapiens_assembly19.targets_germline_copy_number_variants_X_Y_removed.bed --panelOfNormals /Users/aaronc/Documents/recapseg-hb-eval/Mega_PoN_v2.6.pon --factorNormalizedOutput /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/tumor_pcov/HCC1143.fnt.tsv --output /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/tumor_pcov/HCC1143.tn.tsv --betaHatsOutput /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/tumor_pcov/HCC1143.betaHats.tsv --preTangentNormalizationOutput /Users/aaronc/Documents/recapseg-hb-eval/cluster_queue_out/tumor_pcov/HCC1143.preTN.tsv  --help false --version false --verbosity INFO --QUIET false
-#title = Tangent normalized coverage profile
 name	contig	start	stop	HCC1143
 target_1_None	1	30366	30503	-0.5518419553464382
 target_2_None	1	69089	70010	-0.19983169272638943


### PR DESCRIPTION
-Made corresponding minor changes to ACNV classes and tests.
-Cleaned up imports.
-Minor issues: closes #315, closes #320.