### PR TITLE
Exposed a lot more CBS parameters for PerformSegmentation CLI.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/PerformSegmentation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/PerformSegmentation.java
@@ -92,7 +92,7 @@ public final class PerformSegmentation extends CommandLineProgram {
     protected File weightFile = null;
 
     @Argument(
-            doc = "Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
             shortName = ALPHA_SHORT_NAME,
             fullName = ALPHA_LONG_NAME,
             optional = true

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/PerformSegmentation.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/PerformSegmentation.java
@@ -16,6 +16,40 @@ public final class PerformSegmentation extends CommandLineProgram {
     public static final String TARGET_WEIGHT_FILE_LONG_NAME= "targetWeights";
     public static final String TARGET_WEIGHT_FILE_SHORT_NAME = "tw";
 
+    public final static String ALPHA_LONG_NAME="alpha";
+    public final static String ALPHA_SHORT_NAME="alpha";
+
+    public final static String NPERM_LONG_NAME="nperm";
+    public final static String NPERM_SHORT_NAME="nperm";
+
+    public final static String PMETHOD_LONG_NAME="pmethod";
+    public final static String PMETHOD_SHORT_NAME="pmethod";
+
+    public final static String MINWIDTH_LONG_NAME="minWidth";
+    public final static String MINWIDTH_SHORT_NAME="minWidth";
+
+    public final static String KMAX_LONG_NAME="kmax";
+    public final static String KMAX_SHORT_NAME="kmax";
+
+    public final static String NMIN_LONG_NAME="nmin";
+    public final static String NMIN_SHORT_NAME="nmin";
+
+    public final static String ETA_LONG_NAME="eta";
+    public final static String ETA_SHORT_NAME="eta";
+
+    public final static String TRIM_LONG_NAME="trim";
+    public final static String TRIM_SHORT_NAME="trim";
+
+    public final static String UNDOSPLITS_LONG_NAME="undoSplits";
+    public final static String UNDOSPLITS_SHORT_NAME="undoSplits";
+
+    public final static String UNDOPRUNE_LONG_NAME="undoPrune";
+    public final static String UNDOPRUNE_SHORT_NAME="undoPrune";
+
+    public final static String UNDOSD_LONG_NAME="undoSD";
+    public final static String UNDOSD_SHORT_NAME="undoSD";
+
+
     @Argument(
             doc = "Name of the sample being segmented",
             fullName = ExomeStandardArgumentDefinitions.SAMPLE_LONG_NAME,
@@ -57,6 +91,94 @@ public final class PerformSegmentation extends CommandLineProgram {
     )
     protected File weightFile = null;
 
+    @Argument(
+            doc = "Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = ALPHA_SHORT_NAME,
+            fullName = ALPHA_LONG_NAME,
+            optional = true
+    )
+    protected Double alpha = 0.01;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = NPERM_SHORT_NAME,
+            fullName = NPERM_LONG_NAME,
+            optional = true
+    )
+    protected Integer nperm = 10000;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = PMETHOD_SHORT_NAME,
+            fullName = PMETHOD_LONG_NAME,
+            optional = true
+    )
+    protected RCBSSegmenter.PMethod pmethod = RCBSSegmenter.PMethod.HYBRID;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = MINWIDTH_SHORT_NAME,
+            fullName = MINWIDTH_LONG_NAME,
+            optional = true
+    )
+    protected Integer minWidth = 2;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = KMAX_SHORT_NAME,
+            fullName = KMAX_LONG_NAME,
+            optional = true
+    )
+    protected Integer kmax = 25;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = NMIN_SHORT_NAME,
+            fullName = NMIN_LONG_NAME,
+            optional = true
+    )
+    protected Integer nmin = 200;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = ETA_SHORT_NAME,
+            fullName = ETA_LONG_NAME,
+            optional = true
+    )
+    protected Double eta = 0.05;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = TRIM_SHORT_NAME,
+            fullName = TRIM_LONG_NAME,
+            optional = true
+    )
+    protected Double trim = 0.025;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = UNDOSPLITS_SHORT_NAME,
+            fullName = UNDOSPLITS_LONG_NAME,
+            optional = true
+    )
+    protected RCBSSegmenter.UndoSplits undoSplits = RCBSSegmenter.UndoSplits.NONE;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = UNDOPRUNE_SHORT_NAME,
+            fullName = UNDOPRUNE_LONG_NAME,
+            optional = true
+    )
+    protected Double undoPrune = 0.05;
+
+    @Argument(
+            doc = "(Advanced) Please see https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf",
+            shortName = UNDOSD_SHORT_NAME,
+            fullName = UNDOSD_LONG_NAME,
+            optional = true
+    )
+    protected Integer undoSD = 3;
+
     @Override
     protected Object doWork() {
         applySegmentation(sampleName, tangentFile, outFile);
@@ -64,6 +186,7 @@ public final class PerformSegmentation extends CommandLineProgram {
     }
 
     private void applySegmentation(String sampleName, String tangentFile, String outFile) {
-        RCBSSegmenter.writeSegmentFile(sampleName, tangentFile, outFile, log, 2, weightFile);
+        RCBSSegmenter.writeSegmentFile(sampleName, tangentFile, outFile, log, weightFile, alpha, nperm, pmethod,
+                minWidth, kmax, nmin, eta, trim, undoSplits, undoPrune, undoSD);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/segmenter/RCBSSegmenter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/segmenter/RCBSSegmenter.java
@@ -15,6 +15,40 @@ public final class RCBSSegmenter {
 
     private static final String R_SCRIPT = "CBS.R";
 
+    public enum UndoSplits {
+
+        // Default is NONE
+        NONE("none"), PRUNE("prune"), SDUNDO("sdundo");
+
+        private final String value;
+
+        UndoSplits(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
+    public enum PMethod {
+
+        // Default is NONE
+        HYBRID("hybrid"), PERM("perm");
+
+        private final String value;
+
+        PMethod(final String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
     private RCBSSegmenter() {
     }
 
@@ -23,7 +57,18 @@ public final class RCBSSegmenter {
      *
      * <p>https://www.bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf</p>
      *
+     * <p>Please see the above documentation for a more detailed description of the parameters.</p>
+     *
      * <p>IMPORTANT:  There is no check that the weights have the same number of entries as the tnFile.</p>
+     *
+     * Wraps the call:
+     * segment(x, weights = NULL, alpha = 0.01, nperm = 10000, p.method =
+     *  c("hybrid", "perm"), min.width=2, kmax=25, nmin=200,
+     *  eta=0.05, sbdry=NULL, trim = 0.025, undo.splits =
+     *  c("none", "prune", "sdundo"), undo.prune=0.05,
+     *  undo.SD=3, verbose=1)
+     *
+     * <p> Note that sbdry and verbose are unavailable through this interface. </p>
      *
      * @param sampleName Name of the sample being run through the segmenter.  Never {@code null}
      * @param tnFile Tangent-normalized targets file.  Never {@code null}
@@ -34,14 +79,24 @@ public final class RCBSSegmenter {
      *                enforced here).  Typically, 1/var(target) is what is used.  All values must be greater than 0.
      *                Use {@code null} if weighting is not desired.  These values should not be log space.
      */
-    public static void writeSegmentFile(final String sampleName, final String tnFile, final String outputFile, final Boolean log, final int minWidth, final File weightFile) {
+    public static void writeSegmentFile(final String sampleName, final String tnFile, final String outputFile,
+                                        final Boolean log, final File weightFile, final double alpha,
+                                        final int nperm, final PMethod pmethod, final int minWidth,
+                                        final int kmax, final int nmin, final double eta, final double trim,
+                                        final UndoSplits undoSplits, final double undoPrune, final int undoSD
+                                        ) {
 
         String logArg = log ? "TRUE" : "FALSE";
         final RScriptExecutor executor = new RScriptExecutor();
         executor.addScript(new Resource(R_SCRIPT, RCBSSegmenter.class));
         /*--args is needed for Rscript to recognize other arguments properly*/
         executor.addArgs("--args", "--sample_name="+sampleName, "--targets_file="+tnFile, "--output_file="+outputFile,
-                "--log2_input="+logArg, "--min_width="+String.valueOf(minWidth));
+                "--log2_input="+logArg, "--min_width="+String.valueOf(minWidth),
+                "--alpha=" + String.valueOf(alpha), "--nperm=" + String.valueOf(nperm),
+                "--pmethod=" + pmethod.toString(), "--kmax=" + String.valueOf(kmax),
+                "--nmin=" + String.valueOf(nmin), "--eta=" + String.valueOf(eta),
+                "--trim=" + String.valueOf(trim), "--undosplits=" + undoSplits.toString(),
+                "--undoprune=" + String.valueOf(undoPrune), "--undoSD=" + String.valueOf(undoSD));
 
         if (weightFile != null) {
 
@@ -59,7 +114,20 @@ public final class RCBSSegmenter {
         executor.exec();
     }
 
+    /**
+     *  Write segment file with default parameters
+     *
+     * @param sampleName Name of the sample being run through the segmenter.  Never {@code null}
+     * @param tnFile Tangent-normalized targets file.  Never {@code null}
+     * @param outputFile Full path to the outputted segment file.  Never {@code null}
+     * @param log whether the tnFile input has already been put into log2CR.  Never {@code null}
+     */
     public static void writeSegmentFile(final String sampleName, final String tnFile, final String outputFile, final Boolean log) {
-        writeSegmentFile(sampleName, tnFile, outputFile, log, 2, null);
+        writeSegmentFile(sampleName, tnFile, outputFile, log, null);
+    }
+
+    public static void writeSegmentFile(final String sampleName, final String tnFile, final String outputFile, final Boolean log, final File weightsFile) {
+        writeSegmentFile(sampleName, tnFile, outputFile, log, weightsFile, 0.01, 10000, PMethod.HYBRID, 2, 25, 200, 0.05,
+                0.025, UndoSplits.NONE, 0.05, 3);
     }
 }

--- a/src/main/resources/org/broadinstitute/hellbender/utils/segmenter/CBS.R
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/segmenter/CBS.R
@@ -12,7 +12,18 @@ option_list <- list(
     make_option(c("--output_file", "-output_file"), dest="output_file", action="store"),
     make_option(c("--log2_input", "-log"), dest="log2_input", action="store"),
     make_option(c("--min_width", "-mw"), dest="min_width", action="store", default=2),
-    make_option(c("--weights_file", "-w"), dest="weights_file", action="store", default=NULL))
+    make_option(c("--weights_file", "-w"), dest="weights_file", action="store", default=NULL),
+    make_option(c("--alpha" , "-alpha" ), dest="alpha" , action="store", type="double"),
+    make_option(c("--nperm" , "-nperm" ), dest="nperm" , action="store", type="integer"),
+    make_option(c("--pmethod" , "-pmethod" ), dest="pmethod" , action="store"),
+    make_option(c("--kmax" , "-kmax" ), dest="kmax" , action="store", type="integer"),
+    make_option(c("--nmin" , "-nmin" ), dest="nmin" , action="store", type="integer"),
+    make_option(c("--eta" , "-eta" ), dest="eta" , action="store", type="double"),
+    make_option(c("--trim" , "-trim" ), dest="trim" , action="store", type="double"),
+    make_option(c("--undosplits" , "-undosplits" ), dest="undosplits" , action="store"),
+    make_option(c("--undoprune" , "-undoprune" ), dest="undoprune" , action="store"),
+    make_option(c("--undoSD" , "-undoSD" ), dest="undoSD" , action="store", type="integer")
+    )
 
 opt <- parse_args(OptionParser(option_list=option_list))
 print(opt)
@@ -24,9 +35,25 @@ output_file=opt[["output_file"]]
 log_input=as.logical(opt[["log2_input"]])
 min_width=opt[["min_width"]]
 weights_file = opt[["weights_file"]]
+alpha=opt[["alpha" ]]
+nperm=opt[["nperm" ]]
+pmethod=opt[["pmethod" ]]
+kmax=opt[["kmax" ]]
+nmin=opt[["nmin" ]]
+eta=opt[["eta" ]]
+trim=opt[["trim" ]]
+undosplits=opt[["undosplits" ]]
+undoprune=opt[["undoprune" ]]
+undoSD=opt[["undoSD" ]]
+
+# segment(x, weights = NULL, alpha = 0.01, nperm = 10000, p.method =
+#  c("hybrid", "perm"), min.width=2, kmax=25, nmin=200,
+#  eta=0.05, sbdry=NULL, trim = 0.025, undo.splits =
+#  c("none", "prune", "sdundo"), undo.prune=0.05,
+#  undo.SD=3, verbose=1)
 
 # Use a function for debugging purposes
-segment_data = function(sample_name, tn_file, output_file, log_input, weights_file) {
+segment_data = function(sample_name, tn_file, output_file, log_input, weights_file, min_width, alpha, nperm, pmethod, kmax, nmin, eta, trim, undosplits, undoprune, undoSD) {
 	# Read in file and extract needed data
 	tn = read.table(tn_file, sep="\t", stringsAsFactors=FALSE, header=TRUE, check.names=FALSE)
 	contig = tn[,"contig"]
@@ -53,9 +80,9 @@ segment_data = function(sample_name, tn_file, output_file, log_input, weights_fi
 
 	# segment has an issue with passing in weights of NULL.  Better to not specify.
 	if (! is.null(weights_file)) {
-		segmented = segment(smooth.CNA(cna_dat), min.width=min_width, weights=weights)$output
+		segmented = segment(smooth.CNA(cna_dat), min.width=min_width, weights=weights,alpha=alpha, nperm=nperm, p.method=pmethod, kmax=kmax, nmin=nmin, eta=eta, trim=trim, undo.splits=undosplits, undo.prune=undoprune, undo.SD=undoSD)$output
 	} else {
-		segmented = segment(smooth.CNA(cna_dat), min.width=min_width)$output
+		segmented = segment(smooth.CNA(cna_dat), min.width=min_width, alpha=alpha, nperm=nperm, p.method=pmethod, kmax=kmax, nmin=nmin, eta=eta, trim=trim, undo.splits=undosplits, undo.prune=undoprune, undo.SD=undoSD)$output
 	}
 
 	# Ensure that there are no too-small values which will be problematic for downstream tools.
@@ -78,4 +105,4 @@ segment_data = function(sample_name, tn_file, output_file, log_input, weights_fi
 	write.table(segmented, file=output_file, sep="\t", quote=FALSE, row.names=FALSE)
 }
 
-segment_data(sample_name, tn_file, output_file, log_input, weights_file)
+segment_data(sample_name, tn_file, output_file, log_input, weights_file, min_width, alpha, nperm, pmethod, kmax, nmin, eta, trim, undosplits, undoprune, undoSD)

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/PerformSegmentationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/PerformSegmentationIntegrationTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.hellbender.tools.exome;
 
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
@@ -13,6 +15,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 
 public class PerformSegmentationIntegrationTest extends CommandLineProgramTest{
 
@@ -74,5 +77,146 @@ public class PerformSegmentationIntegrationTest extends CommandLineProgramTest{
         };
         runCommandLine(arguments);
         SegmenterUnitTest.assertEqualSegments(output, EXPECTED);
+    }
+
+    @Test(dataProvider = "parameterTests")
+    public void testAlternateParametersActuallyChangeData(String [] newArguments) {
+
+        // This test simply tests that if we change the value of the parameter that the output is altered.
+
+        final File INPUT_FILE = new File("src/test/resources/org/broadinstitute/hellbender/utils/segmenter/input/HCC1143_reduced_log.tsv");
+        final File output = createTempFile("gatkcnv.HCC1143", ".seg");
+        final File outputNewParam = createTempFile("gatkcnv.HCC1143.sdundo", ".seg");
+        final File EXPECTED = new File("src/test/resources/org/broadinstitute/hellbender/utils/segmenter/output/HCC1143_reduced_result.seg");
+        final File tmpWeightsFile = IOUtils.createTempFile("integration-weight-file", ".txt");
+        final double [] weights = new double[7677];
+        Arrays.fill(weights, 1.0);
+        ParamUtils.writeValuesToFile(weights, tmpWeightsFile);
+        final String sampleName = "HCC1143";
+        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), true);
+        final String[] arguments = {
+                "--" + ExomeStandardArgumentDefinitions.SAMPLE_LONG_NAME, sampleName,
+                "-" + ExomeStandardArgumentDefinitions.TARGET_FILE_SHORT_NAME, INPUT_FILE.getAbsolutePath(),
+                "-" + ExomeStandardArgumentDefinitions.LOG2_SHORT_NAME,
+                "-" + PerformSegmentation.TARGET_WEIGHT_FILE_SHORT_NAME, tmpWeightsFile.getAbsolutePath(),
+                "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, output.getAbsolutePath(),
+        };
+        runCommandLine(arguments);
+        SegmenterUnitTest.assertEqualSegments(output, EXPECTED);
+
+        List<String> fullNewArgumentsAsList = Lists.newArrayList(arguments);
+        // Change the output file
+        fullNewArgumentsAsList.remove("-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME);
+        fullNewArgumentsAsList.remove(output.getAbsolutePath());
+        fullNewArgumentsAsList.add("-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME);
+        fullNewArgumentsAsList.add(outputNewParam.getAbsolutePath());
+        fullNewArgumentsAsList.addAll(Arrays.asList(newArguments));
+
+        runCommandLine(fullNewArgumentsAsList.toArray(new String[fullNewArgumentsAsList.size()]));
+        SegmenterUnitTest.assertNotEqualSegments(outputNewParam, output);
+
+    }
+
+    @Test
+    public void testAlternateSDUndoParametersActuallyChangeData() {
+
+        // This test simply tests that if we change the value of the parameter that the output is altered.
+
+        final File INPUT_FILE = new File("src/test/resources/org/broadinstitute/hellbender/utils/segmenter/input/HCC1143_reduced_log.tsv");
+        final File output = createTempFile("gatkcnv.HCC1143", ".seg");
+        final File outputNewParam = createTempFile("gatkcnv.HCC1143.sdundo", ".seg");
+
+        final File tmpWeightsFile = IOUtils.createTempFile("integration-weight-file", ".txt");
+        final double [] weights = new double[7677];
+        Arrays.fill(weights, 1.0);
+        ParamUtils.writeValuesToFile(weights, tmpWeightsFile);
+        final String sampleName = "HCC1143";
+        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), true);
+        final String[] arguments = {
+                "--" + ExomeStandardArgumentDefinitions.SAMPLE_LONG_NAME, sampleName,
+                "-" + ExomeStandardArgumentDefinitions.TARGET_FILE_SHORT_NAME, INPUT_FILE.getAbsolutePath(),
+                "-" + ExomeStandardArgumentDefinitions.LOG2_SHORT_NAME,
+                "-" + PerformSegmentation.TARGET_WEIGHT_FILE_SHORT_NAME, tmpWeightsFile.getAbsolutePath(),
+                "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, output.getAbsolutePath(),
+                "-" + PerformSegmentation.UNDOSPLITS_SHORT_NAME, StringUtils.upperCase(RCBSSegmenter.UndoSplits.SDUNDO.toString())
+        };
+        runCommandLine(arguments);
+
+        final String[] newArguments = {
+                "--" + ExomeStandardArgumentDefinitions.SAMPLE_LONG_NAME, sampleName,
+                "-" + ExomeStandardArgumentDefinitions.TARGET_FILE_SHORT_NAME, INPUT_FILE.getAbsolutePath(),
+                "-" + ExomeStandardArgumentDefinitions.LOG2_SHORT_NAME,
+                "-" + PerformSegmentation.TARGET_WEIGHT_FILE_SHORT_NAME, tmpWeightsFile.getAbsolutePath(),
+                "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputNewParam.getAbsolutePath(),
+                "-" + PerformSegmentation.UNDOSPLITS_SHORT_NAME, StringUtils.upperCase(RCBSSegmenter.UndoSplits.SDUNDO.toString()),
+                "-" + PerformSegmentation.UNDOSD_SHORT_NAME, String.valueOf(2)
+        };
+        runCommandLine(newArguments);
+
+        SegmenterUnitTest.assertNotEqualSegments(outputNewParam, output);
+    }
+
+    @Test
+    public void testAlternateSDUndoPruneParametersActuallyChangeData() {
+
+        // This test simply tests that if we change the value of the parameter that the output is altered.
+
+        final File INPUT_FILE = new File("src/test/resources/org/broadinstitute/hellbender/utils/segmenter/input/HCC1143_reduced_log.tsv");
+        final File output = createTempFile("gatkcnv.HCC1143", ".seg");
+        final File outputNewParam = createTempFile("gatkcnv.HCC1143.sdundo", ".seg");
+
+        final File tmpWeightsFile = IOUtils.createTempFile("integration-weight-file", ".txt");
+        final double [] weights = new double[7677];
+        Arrays.fill(weights, 1.0);
+        ParamUtils.writeValuesToFile(weights, tmpWeightsFile);
+        final String sampleName = "HCC1143";
+        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), true);
+        final String[] arguments = {
+                "--" + ExomeStandardArgumentDefinitions.SAMPLE_LONG_NAME, sampleName,
+                "-" + ExomeStandardArgumentDefinitions.TARGET_FILE_SHORT_NAME, INPUT_FILE.getAbsolutePath(),
+                "-" + ExomeStandardArgumentDefinitions.LOG2_SHORT_NAME,
+                "-" + PerformSegmentation.TARGET_WEIGHT_FILE_SHORT_NAME, tmpWeightsFile.getAbsolutePath(),
+                "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, output.getAbsolutePath(),
+                "-" + PerformSegmentation.UNDOSPLITS_SHORT_NAME, StringUtils.upperCase(RCBSSegmenter.UndoSplits.PRUNE.toString())
+        };
+        runCommandLine(arguments);
+
+        final String[] newArguments = {
+                "--" + ExomeStandardArgumentDefinitions.SAMPLE_LONG_NAME, sampleName,
+                "-" + ExomeStandardArgumentDefinitions.TARGET_FILE_SHORT_NAME, INPUT_FILE.getAbsolutePath(),
+                "-" + ExomeStandardArgumentDefinitions.LOG2_SHORT_NAME,
+                "-" + PerformSegmentation.TARGET_WEIGHT_FILE_SHORT_NAME, tmpWeightsFile.getAbsolutePath(),
+                "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, outputNewParam.getAbsolutePath(),
+                "-" + PerformSegmentation.UNDOSPLITS_SHORT_NAME, StringUtils.upperCase(RCBSSegmenter.UndoSplits.PRUNE.toString()),
+                "-" + PerformSegmentation.UNDOPRUNE_SHORT_NAME, String.valueOf(0.1)
+        };
+        runCommandLine(newArguments);
+
+        SegmenterUnitTest.assertNotEqualSegments(outputNewParam, output);
+    }
+
+    @DataProvider(name="parameterTests")
+    public Object[][] someTargetsHDF5PoNCreationData() {
+        return new Object[][] {
+                // Parameter "trim" had to be manually verified (that it was being passed in), since no output values
+                //  actually changed, causing this test to fail.
+                {
+                    new String[]{"-" + PerformSegmentation.UNDOSPLITS_SHORT_NAME, StringUtils.upperCase(RCBSSegmenter.UndoSplits.SDUNDO.toString())}
+                }, {
+                    new String[]{"-" + PerformSegmentation.UNDOSPLITS_SHORT_NAME, StringUtils.upperCase(RCBSSegmenter.UndoSplits.PRUNE.toString())}
+                }, {
+                    new String[]{"-" + PerformSegmentation.ALPHA_SHORT_NAME, String.valueOf(0.001)}
+                }, {
+                    new String[]{"-" + PerformSegmentation.PMETHOD_SHORT_NAME, StringUtils.upperCase(RCBSSegmenter.PMethod.PERM.toString())}
+                }, {
+                    new String[]{"-" + PerformSegmentation.NMIN_SHORT_NAME, String.valueOf(800)}
+                }, {
+                    new String[]{"-" + PerformSegmentation.KMAX_SHORT_NAME, String.valueOf(10)}
+                }, {
+                    new String[]{"-" + PerformSegmentation.MINWIDTH_SHORT_NAME, String.valueOf(5)}
+                }, {
+                    new String[]{"-" + PerformSegmentation.ETA_SHORT_NAME, String.valueOf(0.1)}
+            }
+        };
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/segmenter/SegmenterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/segmenter/SegmenterUnitTest.java
@@ -58,7 +58,7 @@ public class SegmenterUnitTest extends BaseTest {
         Arrays.fill(weights, 1.0);
         final File weightsTmpFile = IOUtils.createTempFile("weights-simple", ".txt");
         ParamUtils.writeValuesToFile(weights, weightsTmpFile);
-        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, 2, weightsTmpFile);
+        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, weightsTmpFile);
         assertEqualSegments(output,EXPECTED);
     }
 
@@ -73,7 +73,7 @@ public class SegmenterUnitTest extends BaseTest {
         weights[10] = 200;
         final File weightsTmpFile = IOUtils.createTempFile("weights-simple", ".txt");
         ParamUtils.writeValuesToFile(weights, weightsTmpFile);
-        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, 2, weightsTmpFile);
+        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, weightsTmpFile);
         assertEqualSegments(output,EXPECTED);
     }
 
@@ -88,7 +88,7 @@ public class SegmenterUnitTest extends BaseTest {
         weights[10] = Double.POSITIVE_INFINITY;
         final File weightsTmpFile = IOUtils.createTempFile("weights-simple", ".txt");
         ParamUtils.writeValuesToFile(weights, weightsTmpFile);
-        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, 2, weightsTmpFile);
+        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, weightsTmpFile);
         assertEqualSegments(output,EXPECTED);
     }
 
@@ -103,7 +103,7 @@ public class SegmenterUnitTest extends BaseTest {
         weights[10] = Double.NEGATIVE_INFINITY;
         final File weightsTmpFile = IOUtils.createTempFile("weights-simple", ".txt");
         ParamUtils.writeValuesToFile(weights, weightsTmpFile);
-        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), true, 2, weightsTmpFile);
+        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), true, weightsTmpFile);
         assertEqualSegments(output,EXPECTED);
     }
 
@@ -119,7 +119,7 @@ public class SegmenterUnitTest extends BaseTest {
         weights[10] = Double.NEGATIVE_INFINITY;
         final File weightsTmpFile = IOUtils.createTempFile("weights-simple", ".txt");
         ParamUtils.writeValuesToFile(weights, weightsTmpFile);
-        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, 2, weightsTmpFile);
+        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, weightsTmpFile);
         assertEqualSegments(output,EXPECTED);
     }
 
@@ -134,7 +134,7 @@ public class SegmenterUnitTest extends BaseTest {
         weights[10] = Double.NaN;
         final File weightsTmpFile = IOUtils.createTempFile("weights-simple", ".txt");
         ParamUtils.writeValuesToFile(weights, weightsTmpFile);
-        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, 2, weightsTmpFile);
+        RCBSSegmenter.writeSegmentFile(sampleName, INPUT_FILE.getAbsolutePath(), output.getAbsolutePath(), false, weightsTmpFile);
         assertEqualSegments(output,EXPECTED);
     }
 
@@ -143,15 +143,34 @@ public class SegmenterUnitTest extends BaseTest {
      * @param actualOutput the actual segmenter output containing file.
      * @param expectedOutput the expected segmenter output containing file.
      * @throws NullPointerException if either {@code actualOutput} or {@code expectedOutput} is {@code null}.
-     * @throws IOException if any was thrown when reading the input files.
      * @throws AssertionError if there are significant between both files.
      */
-    public static void assertEqualSegments(final File actualOutput, final File expectedOutput) throws IOException {
+    public static void assertEqualSegments(final File actualOutput, final File expectedOutput) {
         try (final SegmentReader actual = new SegmentReader(actualOutput);
              final SegmentReader expected = new SegmentReader(expectedOutput)) {
             final List<SegmentMean> actualSegmentMeans = actual.stream().collect(Collectors.toList());
             final List<SegmentMean> expectedSegmentMeans = expected.stream().collect(Collectors.toList());
             Assert.assertEquals(actualSegmentMeans, expectedSegmentMeans);
+        } catch (final IOException ioe) {
+            Assert.fail("Unit test threw exception trying to read segments.", ioe);
+        }
+    }
+
+    /**
+     * Compares the content of two segmenter output files and makes sure that they are NOT the same..
+     * @param left the actual segmenter output containing file.
+     * @param right the expected segmenter output containing file.
+     * @throws NullPointerException if either {@code left} or {@code right} is {@code null}.
+     * @throws AssertionError if the files are the same between both files.
+     */
+    public static void assertNotEqualSegments(final File left, final File right) {
+        try (final SegmentReader actual = new SegmentReader(left);
+             final SegmentReader expected = new SegmentReader(right)) {
+            final List<SegmentMean> actualSegmentMeans = actual.stream().collect(Collectors.toList());
+            final List<SegmentMean> expectedSegmentMeans = expected.stream().collect(Collectors.toList());
+            Assert.assertNotEquals(actualSegmentMeans, expectedSegmentMeans, "Segments were the same when should have been different.");
+        } catch (final IOException ioe) {
+            Assert.fail("Unit test threw exception trying to read segments.", ioe);
         }
     }
 


### PR DESCRIPTION
Closes #325 


Exposes most of the remaining parameters.

Testing only checks that values in the output actually change.  Exact changes would be very onerous to test.  ``trim`` could not be tested this way.  However, output of the R script indicated that alternate values of ``trim`` were being passed in.