### PR TITLE
Changed ACNV segment union to only use CR segments not called neutral.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/allelefraction/AlleleFractionModeller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/allelefraction/AlleleFractionModeller.java
@@ -62,7 +62,7 @@ public final class AlleleFractionModeller {
     // INNER SAMPLER CLASSES -------------------------------------------------------------------------------------------
     // sample mean bias
     @VisibleForTesting
-    protected static final class  MeanBiasSampler implements Sampler<Double, AlleleFractionState, AlleleFractionData> {
+    protected static final class MeanBiasSampler implements Sampler<Double, AlleleFractionState, AlleleFractionData> {
         private final AdaptiveMetropolisSampler sampler;
 
         public MeanBiasSampler(final double initialMeanBias, final double initialStepSize) {
@@ -76,7 +76,7 @@ public final class AlleleFractionModeller {
 
     // sample bias variance
     @VisibleForTesting
-    protected static final class  BiasVarianceSampler implements Sampler<Double, AlleleFractionState, AlleleFractionData> {
+    protected static final class BiasVarianceSampler implements Sampler<Double, AlleleFractionState, AlleleFractionData> {
         private final AdaptiveMetropolisSampler sampler;
 
         public BiasVarianceSampler(final double initialBiasVariance, final double initialStepSize) {
@@ -90,7 +90,7 @@ public final class AlleleFractionModeller {
 
     // sample outlier probability
     @VisibleForTesting
-    protected static final class  OutlierProbabilitySampler implements Sampler<Double, AlleleFractionState, AlleleFractionData> {
+    protected static final class OutlierProbabilitySampler implements Sampler<Double, AlleleFractionState, AlleleFractionData> {
         private final AdaptiveMetropolisSampler sampler;
 
         public OutlierProbabilitySampler(final double initialOutlierProbability, final double initialStepSize) {
@@ -232,13 +232,13 @@ public final class AlleleFractionModeller {
             final double f = indicator == AlleleFractionIndicator.ALT_MINOR ? minorFraction : 1 - minorFraction;
             final int n = a + r;
             final double w = (1 - f) * (a - alpha + 1) + beta * f;
-            final double lambda0 = (sqrt(w * w + 4 * beta * f * (1 - f) * (r + alpha  - 1)) - w) / (2 * beta * (1 - f));
+            final double lambda0 = (sqrt(w * w + 4 * beta * f * (1 - f) * (r + alpha - 1)) - w) / (2 * beta * (1 - f));
             final double y = (1 - f)/(f + (1 - f) * lambda0);
             final double kappa = n * y * y - (r + alpha - 1) / (lambda0 * lambda0);
             final double rho = 1 - kappa * lambda0 * lambda0;
             final double tau = -kappa * lambda0;
             final double logc = alpha*log(beta) - Gamma.logGamma(alpha) + a * log(f) + r * log(1 - f)
-                    + (r + alpha  - rho) * log(lambda0) + (tau - beta) * lambda0 - n * log(f + (1 - f) * lambda0);
+                    + (r + alpha - rho) * log(lambda0) + (tau - beta) * lambda0 - n * log(f + (1 - f) * lambda0);
 
             return log((1 - pi) / 2) + logc + Gamma.logGamma(rho) - rho * log(tau);
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/PlotSegmentedCopyRatioIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/PlotSegmentedCopyRatioIntegrationTest.java
@@ -4,12 +4,10 @@ import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
-import org.broadinstitute.hellbender.utils.plotter.CopyRatioSegmentedPlotter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.io.IOException;
 
 public class PlotSegmentedCopyRatioIntegrationTest extends CommandLineProgramTest{
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/SegmentMergeUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/SegmentMergeUtilsUnitTest.java
@@ -37,6 +37,68 @@ public final class SegmentMergeUtilsUnitTest extends BaseTest {
         SegmentMergeUtils.mergeSegments(segment1, segment4);
     }
 
+    @DataProvider(name = "dataNeutralSegmentMerging")
+    public Object[][] dataNeutralSegmentMerging() {
+        return new Object[][]{
+                //=================================================================================================
+                {
+                        //segments to merge
+                        Arrays.asList(
+                                //no calls, merge all
+                                new ModeledSegment(new SimpleInterval("1", 1, 10), 1, 0),
+                                new ModeledSegment(new SimpleInterval("1", 11, 20), 1, 0),
+                                new ModeledSegment(new SimpleInterval("1", 21, 30), 1, 0),
+                                new ModeledSegment(new SimpleInterval("2", 1, 10), 1, 0),
+                                new ModeledSegment(new SimpleInterval("2", 11, 20), 1, 0),
+                                new ModeledSegment(new SimpleInterval("2", 21, 30), 1, 0)
+                        ),
+                        //expected merged segments
+                        Arrays.asList(
+                                new SimpleInterval("1", 1, 30),
+                                new SimpleInterval("2", 1, 30)
+                        )
+                },
+                //=================================================================================================
+                {
+                        //segments to merge
+                        Arrays.asList(
+                                new ModeledSegment(new SimpleInterval("1", 1, 10), ReCapSegCaller.AMPLIFICATION_CALL, 1, 0),
+                                new ModeledSegment(new SimpleInterval("1", 11, 20), ReCapSegCaller.NEUTRAL_CALL, 1, 0),  //merge right
+                                new ModeledSegment(new SimpleInterval("1", 21, 30), ReCapSegCaller.NEUTRAL_CALL, 1, 0),
+                                new ModeledSegment(new SimpleInterval("1", 31, 40), ReCapSegCaller.DELETION_CALL, 1, 0),
+                                new ModeledSegment(new SimpleInterval("1", 41, 50), ReCapSegCaller.AMPLIFICATION_CALL, 1, 0),
+                                new ModeledSegment(new SimpleInterval("1", 51, 60), ReCapSegCaller.NEUTRAL_CALL, 1, 0),
+                                new ModeledSegment(new SimpleInterval("2", 1, 10), ReCapSegCaller.AMPLIFICATION_CALL, 1, 0),
+                                new ModeledSegment(new SimpleInterval("2", 11, 20), ReCapSegCaller.NEUTRAL_CALL, 1, 0),  //merge right twice
+                                new ModeledSegment(new SimpleInterval("2", 21, 30), ReCapSegCaller.NEUTRAL_CALL, 1, 0),
+                                new ModeledSegment(new SimpleInterval("2", 31, 40), ReCapSegCaller.NEUTRAL_CALL, 1, 0),
+                                new ModeledSegment(new SimpleInterval("2", 41, 50), ReCapSegCaller.AMPLIFICATION_CALL, 1, 0),
+                                new ModeledSegment(new SimpleInterval("2", 51, 60), ReCapSegCaller.NEUTRAL_CALL, 1, 0)
+                        ),
+                        //expected merged segments
+                        Arrays.asList(
+                                new SimpleInterval("1", 1, 10),
+                                new SimpleInterval("1", 11, 30),
+                                new SimpleInterval("1", 31, 40),
+                                new SimpleInterval("1", 41, 50),
+                                new SimpleInterval("1", 51, 60),
+                                new SimpleInterval("2", 1, 10),
+                                new SimpleInterval("2", 11, 40),
+                                new SimpleInterval("2", 41, 50),
+                                new SimpleInterval("2", 51, 60)
+                        )
+                }
+        };
+    }
+
+    @Test(dataProvider = "dataNeutralSegmentMerging")
+    public void testNeutralSegmentMerging(final List<ModeledSegment> segments,
+                                          final List<SimpleInterval> expectedMergedSegments) {
+        final List<SimpleInterval> resultMergedSegments =
+                SegmentMergeUtils.mergeNeutralSegments(segments);
+        Assert.assertEquals(resultMergedSegments, expectedMergedSegments);
+    }
+
     /**
      * Tests for small-segment merging, along with methods for constructing test data.
      */


### PR DESCRIPTION
By default.  Also added flag to allow use of all CR segments and changed some default parameter values to those used in evaluation.  Closes #331, closes #333.