### PR TITLE
Added normal-only mode to GetHetCoverage.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/AnnotateTargets.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/AnnotateTargets.java
@@ -11,7 +11,10 @@ import org.broadinstitute.hellbender.utils.Nucleotide;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.BitSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Tool to annotate targets.

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/PoNIssueDetector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/PoNIssueDetector.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.tools.exome;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Doubles;
-import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.linear.RealVector;
 import org.apache.commons.math3.stat.descriptive.rank.Median;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/ReadCountCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/ReadCountCollection.java
@@ -7,7 +7,6 @@ import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.DefaultRealMatrixChangingVisitor;
 import org.apache.commons.math3.linear.DefaultRealMatrixPreservingVisitor;
 import org.apache.commons.math3.linear.RealMatrix;
-import org.apache.commons.math3.stat.descriptive.moment.Variance;
 import org.broadinstitute.hellbender.utils.GATKProtectedMathUtils;
 import org.broadinstitute.hellbender.utils.Utils;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/TargetTableAnnotationManager.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/TargetTableAnnotationManager.java
@@ -5,7 +5,8 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.tsv.DataLine;
 import org.broadinstitute.hellbender.utils.tsv.TableColumnCollection;
 
-import java.util.*;
+import java.util.EnumMap;
+import java.util.Map;
 
 /**
  * Target table annotation collection.

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/AllelicCNVIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/AllelicCNVIntegrationTest.java
@@ -10,7 +10,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class AllelicCNVIntegrationTest extends CommandLineProgramTest {

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/CalculateCoverageZScoresIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/CalculateCoverageZScoresIntegrationTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.tools.exome;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
To be used for allelic-PoN exploratory work where the tumor pulldown is not needed.