### PR TITLE
Update build.gradle for compatibility with gradle 2.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.3.1'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.2'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
     }
 }
 


### PR DESCRIPTION
1.2.3 introduces compatibility with Gradle 2.11+. Gradle 2.11+ builds fail with shadowJar 1.2.2.