### PR TITLE
fix the incomplete manifest in sparkJar and shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ logger.info("build for version:" + version);
 group = 'org.broadinstitute'
 
 
-jar {
+tasks.withType(Jar) {
     manifest {
         attributes 'Implementation-Title': 'Hellbender-Protected-Tools',
                 'Implementation-Version': version,


### PR DESCRIPTION
I messed up the shadow and spark jars with my previous commit.  I thought the settings on the jar task would propogate to the shadow tasks, but it turns out they didn't.  I'd checked to make sure that they still had a manifest, but it turned out they had an empty manifest.

This fixes it.