### PR TITLE
Fix -bamout HaplotypeCaller argument

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerArgumentCollection.java
@@ -63,7 +63,7 @@ public abstract class AssemblyBasedCallerArgumentCollection extends StandardCall
      */
     @Advanced
     @Argument(fullName="bamOutput", shortName="bamout", doc="File to which assembled haplotypes should be written", optional = true)
-    public String bamWriter = null;
+    public String bamOutputPath = null;
 
     /**
      * The type of BAM output we want to see. This determines whether HC will write out all of the haplotypes it


### PR DESCRIPTION
The HaplotypeBamWriter was being created in the wrong place,
causing the bam produced by -bamout to be truncated.
Fixed this and added an integration test for the -bamout
argument.

Resolves #465