### PR TITLE
eliminate eager string construction in assertion. Takes 3% of runtime of HC

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/RefVsAnyResult.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/RefVsAnyResult.java
@@ -1,7 +1,5 @@
 package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 
-import org.broadinstitute.hellbender.utils.Utils;
-
 import java.util.stream.DoubleStream;
 
 /**
@@ -56,12 +54,16 @@ final class RefVsAnyResult {
     }
 
     void incrementRefAD(final int by){
-        Utils.validateArg(by >= 0, "expected a non-negative number but got " + by);
+        if (by < 0){
+            throw new IllegalArgumentException("expected a non-negative number but got " + by);
+        }
         refDepth += by;
     }
 
     void incrementNonRefAD(final int by){
-        Utils.validateArg(by >= 0, "expected a non-negative number but got " + by);
+        if (by < 0){
+            throw new IllegalArgumentException("expected a non-negative number but got " + by);
+        }
         nonRefDepth += by;
     }
 


### PR DESCRIPTION
The String was built regardless of whether the test fails or succeeds which was wasteful. Shows up on HC profile.

@lbergelson, ok?