### PR TITLE
Added a method for HMMs to generate a random hidden sequence. Closes #456.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedMathUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedMathUtils.java
@@ -1,13 +1,17 @@
 package org.broadinstitute.hellbender.utils;
 
+import org.apache.commons.math3.distribution.EnumeratedDistribution;
 import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.random.RandomGenerator;
 import org.apache.commons.math3.stat.descriptive.moment.Variance;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
-import org.apache.commons.math3.util.FastMath;
+import org.apache.commons.math3.util.Pair;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -15,7 +19,6 @@ import java.util.stream.IntStream;
  * Created by davidben on 1/22/16.
  */
 public class GATKProtectedMathUtils {
-
     /**
      * Computes $\log(\sum_i e^{a_i})$ trying to avoid underflow issues by using the log-sum-exp trick.
      *
@@ -149,5 +152,13 @@ public class GATKProtectedMathUtils {
     public static double stdDev(final double ... values) {
         Utils.nonNull(values);
         return Math.sqrt(new Variance().evaluate(values));
+    }
+
+    // given a list of options and a function for calculating their probabilities (these must sum to 1 over the whole list)
+    // randomly choose one option from the implied categorical distribution
+    public static <E> E randomSelect(final List<E> choices, final Function<E, Double> probabilityFunction, final RandomGenerator rng) {
+        final List<Pair<E, Double>> pmf = choices.stream()
+                .map(e -> new Pair<>(e, probabilityFunction.apply(e))).collect(Collectors.toList());
+        return new EnumeratedDistribution<>(rng, pmf).sample();
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/GATKProtectedMathUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/GATKProtectedMathUtilsTest.java
@@ -1,10 +1,17 @@
 package org.broadinstitute.hellbender.utils;
 
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
+import org.apache.commons.math3.random.RandomGenerator;
+import org.apache.commons.math3.random.RandomGeneratorFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Created by davidben on 1/22/16.
@@ -113,4 +120,28 @@ public class GATKProtectedMathUtilsTest {
         Assert.assertEquals(columnStdDevs[3], 13.65039682, 1e-8);
     }
 
+    @Test
+    public void testRandomSelectFlatProbability() {
+        final RandomGenerator rg = RandomGeneratorFactory.createRandomGenerator(new Random(13));
+        final int NUM_SAMPLES = 1000;
+        final List<Integer> choices = Arrays.asList(0,1,2);
+        final List<Integer> result = IntStream.range(0, NUM_SAMPLES)
+                .map(n -> GATKProtectedMathUtils.randomSelect(choices, j -> 1.0 / choices.size(), rg))
+                .boxed()
+                .collect(Collectors.toList());
+        Assert.assertEquals(result.stream().filter(n -> n==0).count(), NUM_SAMPLES/choices.size(), 50);
+    }
+
+    @Test
+    public void testRandomSelect() {
+        final RandomGenerator rg = RandomGeneratorFactory.createRandomGenerator(new Random(13));
+        final int NUM_SAMPLES = 1000;
+        final List<Integer> choices = Arrays.asList(-1,0,1);
+        final List<Integer> result = IntStream.range(0, NUM_SAMPLES)
+                .map(n -> GATKProtectedMathUtils.randomSelect(choices, j -> j*j/2.0, rg))
+                .boxed()
+                .collect(Collectors.toList());
+        Assert.assertEquals(result.stream().filter(n -> n==0).count(), 0);
+        Assert.assertEquals(result.stream().filter(n -> n==1).count(), NUM_SAMPLES/2, 50);
+    }
 }


### PR DESCRIPTION
This is going to make writing tests for the germline (and possibly later somatic) segmentation easier.  As an example, this PR already uses the new method to simplify a lot of code in the germline integration tests.

@samuelklee would you mind taking a look at this?