### PR TITLE
Speeding up the writing to disk of a PoN 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Requirements
 * HDF5-Java JNI Libraries Release 2.9 (2.11 for Macs)
 
 * (Developers) Gradle 2.12 is needed for building the GATK. We recommend using the `./gradlew` script which will
-download and use an appropriate gradle version automatically
+download and use an appropriate gradle version automatically.
 
-* (Developers) git lfs 1.1.0 (or greater) is needed for testing GATK-Protected builds.  It is needed to download large files for the complete test suite. Run git lfs install after downloading, followed by git lfs pull to download the large files. The download is ~500 MB.
+* (Developers) git lfs 1.1.0 (or greater) is needed for testing GATK-Protected builds.  It is needed to download large files for the complete test suite. Run ``git lfs install`` after downloading, followed by ``git lfs pull`` to download the large files. The download is ~500 MB.
 
 
 Read GATK 4 README

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Requirements
 
 * HDF5-Java JNI Libraries Release 2.9 (2.11 for Macs)
 
-* Gradle 2.12 is needed for building the GATK. We recommend using the `./gradlew` script which will 
+* (Developers) Gradle 2.12 is needed for building the GATK. We recommend using the `./gradlew` script which will
 download and use an appropriate gradle version automatically
+
+* (Developers) git lfs 1.1.0 (or greater) is needed for testing GATK-Protected builds.  It is needed to download large files for the complete test suite. Run git lfs install after downloading, followed by git lfs pull to download the large files. The download is ~500 MB.
 
 
 Read GATK 4 README

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/TargetPadder.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/TargetPadder.java
@@ -69,7 +69,7 @@ public final class TargetPadder {
         return new Target(t.getName(), new SimpleInterval(t.getContig(), Math.max(1, t.getStart() - paddingInBases), t.getEnd() + paddingInBases));
     }
 
-    protected static Target createTargetFromBEDFeature(final BEDFeature bedFeature) {
+    public static Target createTargetFromBEDFeature(final BEDFeature bedFeature) {
         return new Target(bedFeature.getName(), new SimpleInterval(bedFeature.getContig(), bedFeature.getStart(), bedFeature.getEnd()));
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5File.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5File.java
@@ -95,7 +95,7 @@ public final class HDF5File implements AutoCloseable {
     }
 
     /**
-     * Close this file reader.
+     * Flush and close this file reader.
      *
      * <p>
      *     Further file read operations will result in a {@link IllegalStateException}.
@@ -105,12 +105,28 @@ public final class HDF5File implements AutoCloseable {
         if (isClosed()) {
             return;
         }
+        flush();
         try {
             H5.H5Fclose(fileId);
             fileId = FILE_ID_WHEN_CLOSED;
         } catch (final HDF5LibraryException e) {
             throw new GATKException(
                     String.format("failure when closing '%s' from read-only access: %s",file.getAbsolutePath(),e.getMessage()),e);
+        }
+    }
+
+    /**
+     * Flush this file.
+     */
+    public void flush() {
+        if (isClosed()) {
+            return;
+        }
+        try {
+            H5.H5Fflush(fileId, HDF5Constants.H5F_SCOPE_GLOBAL);
+        } catch (final HDF5LibraryException e) {
+            throw new GATKException(
+                    String.format("failure when flushing '%s': %s",file.getAbsolutePath(),e.getMessage()),e);
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5File.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5File.java
@@ -116,7 +116,7 @@ public final class HDF5File implements AutoCloseable {
     }
 
     /**
-     * Flush this file.
+     * Flush this file reader (through the HDF5 API) to disk rather than waiting for the OS to handle it.
      */
     public void flush() {
         if (isClosed()) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoN.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoN.java
@@ -16,9 +16,20 @@ import java.util.function.IntPredicate;
 /**
  * HDF5 File backed Panel of Normals data structure.
  *
- * Several attributes are stored transposed, in order to dodge a very slow write time in HDF5.
- *  Normalized Counts
- *  Log-Normalized Counts
+ * Several attributes are stored transposed (in other words, the rows are columns and vice versa).
+ * This dodges a very slow write time in HDF5, since we usually have many more rows (targets) than columns (samples).
+ *
+ * HDF5 can write matrices with few rows and many columns much faster than matrices with many rows and few columns.
+ *
+ * <ul>
+ *  <li>Normalized Counts</li>
+ *  <li>Log-Normalized Counts</li>
+ *  <li>Reduced Panel counts</li>
+ *</ul>
+ *
+ * In these cases, the samples are the rows and the targets are the columns.
+ *
+ * This is only for storage.  When saving/loading the above attributes, the transposing is handled transparently.
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
@@ -278,14 +289,16 @@ public final class HDF5PoN implements PoN {
 
     @Override
     public RealMatrix getNormalizedCounts() {
-        // Note the check is using sample names as number of rows and targets as number of columns....
+        // Note the check uses sample names as number of rows and targets as number of columns.  This is due to the
+        //  transposed storage.  The returned matrix is still targets (rows) x samples (columns).
         return readMatrixAndCheckDimensions(NORMALIZED_PCOV_PATH, sampleNames.get().size(), targetNames.get().size())
                 .transpose();
     }
 
     @Override
     public RealMatrix getLogNormalizedCounts() {
-        // Note the check is using sample names as number of rows and targets as number of columns....
+        // Note the check uses sample names as number of rows and targets as number of columns.  This is due to the
+        //  transposed storage.  The returned matrix is still targets (rows) x samples (columns).
         return readMatrixAndCheckDimensions(LOG_NORMALS_PATH, getPanelSampleNames().size(), getPanelTargetNames().size())
                 .transpose();
     }
@@ -298,7 +311,8 @@ public final class HDF5PoN implements PoN {
 
     @Override
     public RealMatrix getReducedPanelCounts() {
-        // Note the check is using sample names as number of rows and targets as number of columns....
+        // Note the check is using sample names as number of rows and targets as number of columns.  This is due to the
+        //  transposed storage.  The returned matrix is still targets (rows) x pseudo-samples (columns).
         return readMatrixAndCheckDimensions(REDUCED_PON_PATH,
                 c -> c <= getPanelSampleNames().size(),
                 r -> r == reducedTargetNames.get().size()).transpose();

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoN.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoN.java
@@ -16,7 +16,7 @@ import java.util.function.IntPredicate;
 /**
  * HDF5 File backed Panel of Normals data structure.
  *
- * Several attributes are stored transposed (in other words, the rows are columns and vice versa).
+ * Several attributes are stored transposed (in other words, the rows and columns are interchanged).
  * This dodges a very slow write time in HDF5, since we usually have many more rows (targets) than columns (samples).
  *
  * HDF5 can write matrices with few rows and many columns much faster than matrices with many rows and few columns.

--- a/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoNCreator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoNCreator.java
@@ -85,7 +85,9 @@ final public class HDF5PoNCreator {
 
         // Remove low coverage targets:
         final ReadCountCollection inputPCov = readReadCountsFromFile(inputPCovFile, initialTargets);
-        createPoNGivenReadCountCollection(ctx, inputPCov, numberOfEigenSamples, sampleNameBlacklist, outputHDF5Filename, isDryRun, initialTargets, targetFactorPercentileThreshold, extremeColumnMedianCountPercentileThreshold, countTruncatePercentile, maximumPercentageZeroTargets, maximumPercentageZeroColumns);
+        createPoNGivenReadCountCollection(ctx, inputPCov, numberOfEigenSamples, sampleNameBlacklist, outputHDF5Filename,
+                isDryRun, initialTargets, targetFactorPercentileThreshold, extremeColumnMedianCountPercentileThreshold,
+                countTruncatePercentile, maximumPercentageZeroTargets, maximumPercentageZeroColumns);
     }
 
     /**
@@ -159,13 +161,13 @@ final public class HDF5PoNCreator {
             logger.info("Setting log-normal pinv (" + reduction.getPseudoInverse().getRowDimension() +
                     " x " + reduction.getPseudoInverse().getColumnDimension() + ") ...");
             pon.setLogNormalPInverseCounts(reduction.getPseudoInverse());
-            logger.info("Setting reduced panel (" + reduction.getReducedCounts().getRowDimension() +
+            logger.info("Setting reduced panel counts (" + reduction.getReducedCounts().getRowDimension() +
                     " x " + reduction.getReducedCounts().getColumnDimension() + ") (T) ...");
             pon.setReducedPanelCounts(reduction.getReducedCounts());
             logger.info("Setting reduced panel pinv (" + reduction.getReducedInverse().getRowDimension() +
                     " x " + reduction.getReducedInverse().getColumnDimension() + ") ...");
             pon.setReducedPanelPInverseCounts(reduction.getReducedInverse());
-            logger.info("Setting reduced targets ...");
+            logger.info("Setting reduced panel targets ...");
             pon.setPanelTargets(readCounts.targets());
             logger.info("Setting version number (" + CURRENT_PON_VERSION + ")...");
             pon.setVersion(CURRENT_PON_VERSION);
@@ -189,7 +191,7 @@ final public class HDF5PoNCreator {
             pon.setTargetNames(targetNames);
             logger.info("Setting target factors (" + targetFactors.length + ") ...");
             pon.setTargetFactors(new Array2DRowRealMatrix(targetFactors));
-            logger.info("Setting normal counts (" + readCounts.counts().getRowDimension() +
+            logger.info("Setting coverage profile (" + readCounts.counts().getRowDimension() +
                     " x " + readCounts.counts().getColumnDimension() + ") (T)...");
             pon.setNormalCounts(readCounts.counts());
             logger.info("Setting targets ...");

--- a/src/test/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoNCreatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoNCreatorUnitTest.java
@@ -3,9 +3,7 @@ package org.broadinstitute.hellbender.utils.hdf5;
 import org.apache.commons.collections4.list.SetUniqueList;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
-import org.apache.commons.math3.linear.DefaultRealMatrixChangingVisitor;
 import org.apache.commons.math3.linear.RealMatrix;
-import org.apache.commons.math3.random.RandomDataGenerator;
 import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.apache.commons.math3.stat.descriptive.rank.Median;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
@@ -66,36 +64,6 @@ public class HDF5PoNCreatorUnitTest extends BaseTest {
             final double[] targetVariances = pon.getTargetVariances();
             PoNTestUtils.assertEqualsDoubleArrays(targetVariances, gtTargetVariances);
         }
-    }
-
-    @Test
-    public void testCreateLargePoN(){
-        // final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
-        // Creates a large PoN of junk values.
-        final int numEigenSamples = 20;
-
-//        // Load a lot of targets from a bed file
-//        final TargetCollection<? extends BEDFeature> inputTargetCollection = TargetUtils.readTargetFile(new File(BIG_TARGET_LIST));
-//        final List<Target> targetList = inputTargetCollection.targets().stream().map(TargetPadder::createTargetFromBEDFeature).collect(Collectors.toList());
-
-
-        // Make a big, fake set of read counts.
-        final RealMatrix bigCounts = new Array2DRowRealMatrix(3000000, 10);
-        final RandomDataGenerator randomDataGenerator = new RandomDataGenerator();
-        bigCounts.walkInColumnOrder(new DefaultRealMatrixChangingVisitor() {
-            @Override
-            public double visit(int row, int column, double value) {
-                return randomDataGenerator.nextGaussian(3e-7, 1e-9);
-            }
-        });
-        final File tempOutputPoN = IOUtils.createTempFile("big-ol-", ".pon");
-        final HDF5File hdf5File = new HDF5File(tempOutputPoN, HDF5File.OpenMode.CREATE);
-        hdf5File.makeDoubleMatrix("/test/m", bigCounts.getData());
-        hdf5File.close();
-        final int nxumEigenSamples = 40;
-//        final ReadCountCollection bigDummyRCC = new ReadCountCollection(final SetUniqueList<Target> targets, final SetUniqueList<String> columnNames, final RealMatrix counts)
-
-//        final File ponFile = PoNTestUtils.createDummyHDF5FilePoN(, numEigenSamples);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoNCreatorUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/hdf5/HDF5PoNCreatorUnitTest.java
@@ -3,7 +3,9 @@ package org.broadinstitute.hellbender.utils.hdf5;
 import org.apache.commons.collections4.list.SetUniqueList;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
+import org.apache.commons.math3.linear.DefaultRealMatrixChangingVisitor;
 import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.random.RandomDataGenerator;
 import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.apache.commons.math3.stat.descriptive.rank.Median;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
@@ -43,9 +45,11 @@ import java.util.stream.Stream;
  */
 public class HDF5PoNCreatorUnitTest extends BaseTest {
     private final static String TEST_DIR = "src/test/resources/org/broadinstitute/hellbender/tools/exome/";
+    private final static String LARGE_TEST_DIR = "src/test/resources/large/";
     private final static String TEST_PCOV_FILE = "create-pon-control-full.pcov";
     private final static String GT_TARGET_VAR_FILE = TEST_DIR + "dummy_pon_target_variances_matlab.txt";
     private final static String TEST_FULL_PON = TEST_DIR + "create-pon-all-targets.pon";
+    private final static String BIG_TARGET_LIST = LARGE_TEST_DIR + "test_wgs_1k_bins.bed";
 
     @Test
     public void testCreateVariance() {
@@ -62,6 +66,36 @@ public class HDF5PoNCreatorUnitTest extends BaseTest {
             final double[] targetVariances = pon.getTargetVariances();
             PoNTestUtils.assertEqualsDoubleArrays(targetVariances, gtTargetVariances);
         }
+    }
+
+    @Test
+    public void testCreateLargePoN(){
+        // final JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+        // Creates a large PoN of junk values.
+        final int numEigenSamples = 20;
+
+//        // Load a lot of targets from a bed file
+//        final TargetCollection<? extends BEDFeature> inputTargetCollection = TargetUtils.readTargetFile(new File(BIG_TARGET_LIST));
+//        final List<Target> targetList = inputTargetCollection.targets().stream().map(TargetPadder::createTargetFromBEDFeature).collect(Collectors.toList());
+
+
+        // Make a big, fake set of read counts.
+        final RealMatrix bigCounts = new Array2DRowRealMatrix(3000000, 10);
+        final RandomDataGenerator randomDataGenerator = new RandomDataGenerator();
+        bigCounts.walkInColumnOrder(new DefaultRealMatrixChangingVisitor() {
+            @Override
+            public double visit(int row, int column, double value) {
+                return randomDataGenerator.nextGaussian(3e-7, 1e-9);
+            }
+        });
+        final File tempOutputPoN = IOUtils.createTempFile("big-ol-", ".pon");
+        final HDF5File hdf5File = new HDF5File(tempOutputPoN, HDF5File.OpenMode.CREATE);
+        hdf5File.makeDoubleMatrix("/test/m", bigCounts.getData());
+        hdf5File.close();
+        final int nxumEigenSamples = 40;
+//        final ReadCountCollection bigDummyRCC = new ReadCountCollection(final SetUniqueList<Target> targets, final SetUniqueList<String> columnNames, final RealMatrix counts)
+
+//        final File ponFile = PoNTestUtils.createDummyHDF5FilePoN(, numEigenSamples);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/utils/hdf5/PoNTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/hdf5/PoNTestUtils.java
@@ -5,12 +5,10 @@ import com.opencsv.CSVReader;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
-import org.broadinstitute.hellbender.tools.exome.CreatePanelOfNormals;
-import org.broadinstitute.hellbender.tools.exome.Target;
-import org.broadinstitute.hellbender.tools.exome.TargetArgumentCollection;
-import org.broadinstitute.hellbender.tools.exome.TargetCollection;
+import org.broadinstitute.hellbender.tools.exome.*;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
+import org.broadinstitute.hellbender.utils.param.ParamUtils;
 import org.testng.Assert;
 
 import java.io.File;
@@ -33,9 +31,34 @@ public class PoNTestUtils {
      */
     public static File createDummyHDF5FilePoN(final File inputPCovFile, final int numEigenSamples) {
         Utils.regularReadableUserFile(inputPCovFile);
+        ParamUtils.isPositive(numEigenSamples, "Num Eigen samples must be greater than zero.");
         final File outputFile = IOUtils.createTempFile("dummy-pon-", ".pon");
         final TargetCollection<Target> targets = TargetArgumentCollection.readTargetCollection(inputPCovFile);
         HDF5PoNCreator.createPoN(null, inputPCovFile, OptionalInt.of(numEigenSamples), new ArrayList<>(), outputFile, false, targets,
+                CreatePanelOfNormals.DEFAULT_TARGET_FACTOR_THRESHOLD_PERCENTILE,
+                CreatePanelOfNormals.DEFAULT_COLUMN_OUTLIER_DROP_THRESHOLD_PERCENTILE,
+                CreatePanelOfNormals.DEFAULT_OUTLIER_TRUNCATE_PERCENTILE_THRESHOLD,
+                CreatePanelOfNormals.DEFAULT_MAXIMUM_PERCENT_ZEROS_IN_TARGET,
+                CreatePanelOfNormals.DEFAULT_MAXIMUM_PERCENT_ZEROS_IN_COLUMN);
+        return outputFile;
+    }
+
+    /** Creates a HDF5 PoN (using {@link org.broadinstitute.hellbender.utils.hdf5.HDF5PoNCreator} ).  Parameters use the
+     * current {@link CreatePanelOfNormals} defaults.
+     *
+     * This is the same as {@link PoNTestUtils#createDummyHDF5FilePoN}, except that you can ise a ReadCountCollection.
+     *
+     * @param inputPCov ReadCountCollection with the proportional coverages.
+     * @param numEigenSamples number of desired eigen samples in the PoN reduction
+     * @return HDF5 File.  Never {@code null}
+     */
+    public static File createDummyHDF5FilePoN(final ReadCountCollection inputPCov, final int numEigenSamples) {
+        Utils.nonNull(inputPCov);
+        ParamUtils.isPositive(numEigenSamples, "Num Eigen samples must be greater than zero.");
+        final File outputFile = IOUtils.createTempFile("dummy-pon-", ".pon");
+        final TargetCollection<Target> targets = new HashedListTargetCollection<>(inputPCov.targets());
+        HDF5PoNCreator.createPoNGivenReadCountCollection(null, inputPCov, OptionalInt.of(numEigenSamples),
+                new ArrayList<>(), outputFile, false, targets,
                 CreatePanelOfNormals.DEFAULT_TARGET_FACTOR_THRESHOLD_PERCENTILE,
                 CreatePanelOfNormals.DEFAULT_COLUMN_OUTLIER_DROP_THRESHOLD_PERCENTILE,
                 CreatePanelOfNormals.DEFAULT_OUTLIER_TRUNCATE_PERCENTILE_THRESHOLD,

--- a/src/test/java/org/broadinstitute/hellbender/utils/hdf5/PoNTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/hdf5/PoNTestUtils.java
@@ -26,15 +26,15 @@ public class PoNTestUtils {
      * current {@link CreatePanelOfNormals} defaults.
      * @param inputPCovFile regular readable file that could be used to create a PoN.  Must be same format as output of
      *  {@link org.broadinstitute.hellbender.tools.exome.CombineReadCounts}
-     * @param numEigenSamples number of desired eigen samples in the PoN reduction
+     * @param numEigensamples number of desired eigen samples in the PoN reduction
      * @return HDF5 File.  Never {@code null}
      */
-    public static File createDummyHDF5FilePoN(final File inputPCovFile, final int numEigenSamples) {
+    public static File createDummyHDF5FilePoN(final File inputPCovFile, final int numEigensamples) {
         Utils.regularReadableUserFile(inputPCovFile);
-        ParamUtils.isPositive(numEigenSamples, "Num Eigen samples must be greater than zero.");
+        ParamUtils.isPositive(numEigensamples, "Num Eigensamples must be greater than zero.");
         final File outputFile = IOUtils.createTempFile("dummy-pon-", ".pon");
         final TargetCollection<Target> targets = TargetArgumentCollection.readTargetCollection(inputPCovFile);
-        HDF5PoNCreator.createPoN(null, inputPCovFile, OptionalInt.of(numEigenSamples), new ArrayList<>(), outputFile, false, targets,
+        HDF5PoNCreator.createPoN(null, inputPCovFile, OptionalInt.of(numEigensamples), new ArrayList<>(), outputFile, false, targets,
                 CreatePanelOfNormals.DEFAULT_TARGET_FACTOR_THRESHOLD_PERCENTILE,
                 CreatePanelOfNormals.DEFAULT_COLUMN_OUTLIER_DROP_THRESHOLD_PERCENTILE,
                 CreatePanelOfNormals.DEFAULT_OUTLIER_TRUNCATE_PERCENTILE_THRESHOLD,
@@ -46,18 +46,18 @@ public class PoNTestUtils {
     /** Creates a HDF5 PoN (using {@link org.broadinstitute.hellbender.utils.hdf5.HDF5PoNCreator} ).  Parameters use the
      * current {@link CreatePanelOfNormals} defaults.
      *
-     * This is the same as {@link PoNTestUtils#createDummyHDF5FilePoN}, except that you can ise a ReadCountCollection.
+     * This is the same as {@link PoNTestUtils#createDummyHDF5FilePoN}, except that you can use a ReadCountCollection.
      *
      * @param inputPCov ReadCountCollection with the proportional coverages.
-     * @param numEigenSamples number of desired eigen samples in the PoN reduction
+     * @param numEigensamples number of desired eigensamples in the PoN reduction
      * @return HDF5 File.  Never {@code null}
      */
-    public static File createDummyHDF5FilePoN(final ReadCountCollection inputPCov, final int numEigenSamples) {
+    public static File createDummyHDF5FilePoN(final ReadCountCollection inputPCov, final int numEigensamples) {
         Utils.nonNull(inputPCov);
-        ParamUtils.isPositive(numEigenSamples, "Num Eigen samples must be greater than zero.");
+        ParamUtils.isPositive(numEigensamples, "Num Eigensamples must be greater than zero.");
         final File outputFile = IOUtils.createTempFile("dummy-pon-", ".pon");
         final TargetCollection<Target> targets = new HashedListTargetCollection<>(inputPCov.targets());
-        HDF5PoNCreator.createPoNGivenReadCountCollection(null, inputPCov, OptionalInt.of(numEigenSamples),
+        HDF5PoNCreator.createPoNGivenReadCountCollection(null, inputPCov, OptionalInt.of(numEigensamples),
                 new ArrayList<>(), outputFile, false, targets,
                 CreatePanelOfNormals.DEFAULT_TARGET_FACTOR_THRESHOLD_PERCENTILE,
                 CreatePanelOfNormals.DEFAULT_COLUMN_OUTLIER_DROP_THRESHOLD_PERCENTILE,


### PR DESCRIPTION
This was necessary for WGS PoNs.  Even really small PoNs were taking days to finish writing to disk.  The solution was to transpose some of the fields to minimize the number of rows.  The HDF5PoN class has been altered to make the transposing encapsulated away from callers.

Other notes:
- Added hook to create a PoN from a ReadCountCollection, which is much more flexible than insisting on an input file.
- Added flush to the closing of a PoN.  This probably does not do much.
- Minor doc changes.
- More logging during PoN creation.  Makes it look like it is making progress...

Closes #494 
Closes #493 

Removing possibly extraneous instantiation of RamPoN in hopes of saving some RAM during PoN creation

Updated docs.

Updated docs with minor comment.

Updated docs with minor comment.

Updated to show a lot more logging when creating a HDF5 PoN

Better logging in create PoN for HDF5

Adding a flush command,.

Test to make sure that we can write a large matrix to HDF5

Transposing certain fields in a PoN (for storage only) in order to go faster.

Removed test utility that was not being used.