### PR TITLE
add mavenLocal to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ repositories {
             dirs customJarPath
         }
     }
-
+    mavenLocal()
 }
 
 jacocoTestReport {


### PR DESCRIPTION
add mavenLocal to gradle to simplify 2-repo development.

with this change i just need to add 1 line when changing the snapshot build of gatk

I put local before central because it seems to me that local copies should override global ones. conflicts should be very rare
@lbergelson wdyt?