### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer shouldnot be used

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyRegionTestDataSet.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyRegionTestDataSet.java
@@ -301,7 +301,7 @@ public final class AssemblyRegionTestDataSet {
 
     private String applyCigar(final String reference, final String cigar, final int offset, final boolean global) {
         final Matcher pm = cigarPattern.matcher(cigar);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         int index = offset;
         while (pm.find()) {
             int length = Integer.valueOf(pm.group(1));

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/Civar.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/Civar.java
@@ -241,7 +241,7 @@ public final class Civar {
         int nextInSeq = 0;
         int nextElement = 0;
 
-        final StringBuffer sb = new StringBuffer(sequence.length() * 2);
+        final StringBuilder sb = new StringBuilder(sequence.length() * 2);
         while (nextInSeq < to && nextElement < elements.size()) {
             final Element e = elements.get(nextElement++);
             int size = e.expands() ? starPadding * e.size() : e.size();
@@ -334,19 +334,19 @@ public final class Civar {
 
     }
 
-    private void transition(final CharSequence charSequence, final int from, final StringBuffer dest, final int length) {
+    private void transition(final CharSequence charSequence, final int from, final StringBuilder dest, final int length) {
         for (int i = from; i < length + from; i++) {
             dest.append(transition(charSequence.charAt(i)));
         }
     }
 
-    private void transversion(final CharSequence cs, final int from, final StringBuffer dest, final int length) {
+    private void transversion(final CharSequence cs, final int from, final StringBuilder dest, final int length) {
         for (int i = from; i < length + from; i++) {
             dest.append(transversion(cs.charAt(i)));
         }
     }
 
-    private void complement(final CharSequence cs, final int from, final StringBuffer dest, final int length) {
+    private void complement(final CharSequence cs, final int from, final StringBuilder dest, final int length) {
         for (int i = from; i < length + from; i++) {
             dest.append(complement(cs.charAt(i)));
         }
@@ -413,9 +413,9 @@ public final class Civar {
         boolean hasOptionalElements = false;
         boolean allElementsAreOptional = true;
         boolean hasVariation = false;
-        StringBuffer strBuffer = new StringBuffer(100);
+        StringBuilder strBuilder = new StringBuilder(100);
         for (final Element e : elements) {
-            strBuffer.append(e.toString());
+            strBuilder.append(e.toString());
             if (e.operator() == Operator.EMBEDDED) {
                 hasEmbeddedCivars = true;
                 if (e.embedded.hasVariation()) {
@@ -444,7 +444,7 @@ public final class Civar {
                 minimumTemplateSize += e.size();
             }
         }
-        this.string = strBuffer.toString();
+        this.string = strBuilder.toString();
         this.hasVariation = hasVariation;
         this.allVariationIsOptional = allElementsAreOptional;
         this.hasOptionalVariation = hasOptionalElements;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.