### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -77,7 +77,7 @@ public final class ReferenceConfidenceModel {
     /**
      * Phred scaled qual value that corresponds to the {@link #INDEL_ERROR_RATE indel error rate}.
      */
-    private static final byte INDEL_QUAL = (byte) Math.round((INDEL_ERROR_RATE * -10.0));
+    private static final byte INDEL_QUAL = (byte) Math.round(INDEL_ERROR_RATE * -10.0);
 
     /**
      * No indel likelihood (ref allele) used in the indel model to assess the confidence on the hom-ref call.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/graphs/BaseGraph.java
@@ -55,7 +55,7 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
         }
 
         // edge case: if the graph only has one node then it's a ref node, otherwise it's not
-        return (vertexSet().size() == 1);
+        return vertexSet().size() == 1;
     }
 
     /**
@@ -150,7 +150,7 @@ public abstract class BaseGraph<V extends BaseVertex, E extends BaseEdge> extend
         }
 
         // edge case: if the graph only has one node then it's a ref source, otherwise it's not
-        return (vertexSet().size() == 1);
+        return vertexSet().size() == 1;
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/utils/svd/SparkSingularValueDecomposer.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/svd/SparkSingularValueDecomposer.java
@@ -60,7 +60,7 @@ class SparkSingularValueDecomposer {
 
         final Matrix invSMat = Matrices.diag(Vectors.dense(invS));
         logger.info("Pinv: Multiplying V * invS * U' to get the pinv (using pinv transpose = U * invS' * V') ...");
-        final RowMatrix pinvT = (u.multiply(invSMat)).multiply(v);
+        final RowMatrix pinvT = u.multiply(invSMat).multiply(v);
         logger.info("Pinv: Converting back to local matrix ...");
         final RealMatrix pinv = SparkConverter.convertSparkRowMatrixToRealMatrix(pinvT, realMat.getRowDimension()).transpose();
         logger.info("Done calculating the pseudoinverse and converting it...");

--- a/src/test/java/org/broadinstitute/hellbender/tools/exome/SampleCoverageStatsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/exome/SampleCoverageStatsUnitTest.java
@@ -54,7 +54,7 @@ public final class SampleCoverageStatsUnitTest extends BaseTest {
         } else {
             final double mean = sum / size;
             Assert.assertEquals(subject.mean, mean, 0.000001);
-            final double variance = Math.abs((((squaresSum / size) - Math.pow(mean, 2)) * size)) / ((double) size - 1);
+            final double variance = Math.abs((squaresSum / size - Math.pow(mean, 2)) * size) / ((double) size - 1);
             Assert.assertEquals(subject.variance, variance, 0.000001);
         }
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/Civar.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/Civar.java
@@ -600,7 +600,7 @@ public final class Civar {
             if (!expands)
                 return size;
             else
-                return size * (starPadding) + Math.min(excessPaddingRemaining, size);
+                return size * starPadding + Math.min(excessPaddingRemaining, size);
         }
 
         /**
@@ -672,7 +672,7 @@ public final class Civar {
             this(o,size,expands,optional);
             if ((xmer == null || xmer.length() == 0) && o.requiresXmer())
                 throw new IllegalArgumentException("operator  " + o + " requires a x-mer");
-            if ((xmer != null && !o.acceptsXmer()))
+            if (xmer != null && !o.acceptsXmer())
                 throw new IllegalArgumentException("operator  " + o + " does not accept a x-mer");
             this.xmer = xmer;
         }
@@ -1025,7 +1025,7 @@ public final class Civar {
         }
 
         public Element asElement() {
-            return ((Element) content);
+            return (Element) content;
         }
 
         protected static Token xmer(final CharSequence cs) {

--- a/src/test/java/org/broadinstitute/hellbender/utils/codecs/LineIteratorReaderUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/codecs/LineIteratorReaderUnitTest.java
@@ -70,7 +70,7 @@ public class LineIteratorReaderUnitTest {
     private static char[] createRandomLine(final int lineSize) {
         final char[] result = new char[lineSize];
         for (int i = 0; i < result.length; i++) {
-            result[i] = (char) ((RANDOM.nextInt(127 - 32)) + 32);
+            result[i] = (char) (RANDOM.nextInt(127 - 32) + 32);
         }
         return result;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.