### PR TITLE
Primitives should not be boxed just for "String" conversion

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/tsv/TableUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/tsv/TableUtils.java
@@ -32,7 +32,7 @@ public final class TableUtils {
     /**
      * Column separator as an string.
      */
-    public static final String COLUMN_SEPARATOR_STRING = "" + COLUMN_SEPARATOR;
+    public static final String COLUMN_SEPARATOR_STRING = String.valueOf(COLUMN_SEPARATOR);
 
     /**
      * Comment line prefix string {@value}.
@@ -54,7 +54,7 @@ public final class TableUtils {
     /**
      * Quote character as a string.
      */
-    public static final String QUOTE_STRING = "" + QUOTE_CHARACTER;
+    public static final String QUOTE_STRING = String.valueOf(QUOTE_CHARACTER);
 
     /**
      * Escape character {@value #ESCAPE_STRING}.
@@ -70,7 +70,7 @@ public final class TableUtils {
     /**
      * Escape character as a string.
      */
-    public static final String ESCAPE_STRING = "" + ESCAPE_CHARACTER;
+    public static final String ESCAPE_STRING = String.valueOf(ESCAPE_CHARACTER);
 
     /**
      * Creates a new table reader given an record extractor factory based from the columns found in the input.

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/Civar.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/Civar.java
@@ -681,7 +681,7 @@ public final class Civar {
             if (operator() == Operator.EMBEDDED) {
                 return "(" + embedded.toString() + ")";
             }
-            final String sizeString = expands ? (size == 1 ? "*":"" + size) : ("" + size);
+            final String sizeString = expands ? (size == 1 ? "*":String.valueOf(size)) : (String.valueOf(size));
             final String sizeAndOperator = sizeString + operator().charValue;
             final String sizeAndOperatorAndXmer = o == Operator.INSERTION ? sizeAndOperator + xmer : sizeAndOperator;
             return optional ? sizeAndOperatorAndXmer + "?" : sizeAndOperatorAndXmer;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131 - “Primitives should not be boxed just for "String" conversion”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.