### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/PoNIssueDetector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/PoNIssueDetector.java
@@ -31,6 +31,9 @@ public final class PoNIssueDetector {
     final static double AMP_THRESHOLD = 1.12;
     final static double DEL_THRESHOLD = 0.88;
 
+    private PoNIssueDetector() {
+    }
+
     /**
      * Return list of samples in the given PoN that likely contain arm level events.  Samples detected will have to be
      *  removed.

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/SNPSegmenter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/SNPSegmenter.java
@@ -14,6 +14,9 @@ import java.util.stream.Collectors;
  * @author Samuel Lee &lt;slee@broadinstitute.org&gt;
  */
 public final class SNPSegmenter {
+    private SNPSegmenter() {
+    }
+
     /**
      * Write segment file based on maximum-likelihood estimates of the minor allele fraction at SNP sites,
      * assuming no allelic bias.  These estimates are converted to target coverages,

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/acsconversion/ACSModeledSegmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/acsconversion/ACSModeledSegmentUtils.java
@@ -29,6 +29,10 @@ public class ACSModeledSegmentUtils {
      * Made larger at user request.
      */
     public static final double DIVISOR = 2.0;
+
+    private ACSModeledSegmentUtils() {
+    }
+
     /**
      * Writes a list of segments represented by {@link ACNVModeledSegment} to a file with header:
      * <p>

--- a/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedMathUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GATKProtectedMathUtils.java
@@ -19,6 +19,9 @@ import java.util.stream.IntStream;
  * Created by davidben on 1/22/16.
  */
 public class GATKProtectedMathUtils {
+    private GATKProtectedMathUtils() {
+    }
+
     /**
      * Computes $\log(\sum_i e^{a_i})$ trying to avoid underflow issues by using the log-sum-exp trick.
      *

--- a/src/main/java/org/broadinstitute/hellbender/utils/mcmc/PosteriorSummaryUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/mcmc/PosteriorSummaryUtils.java
@@ -28,6 +28,9 @@ public class PosteriorSummaryUtils {
     private static final MaxEval BRENT_MAX_EVAL = new MaxEval(100);
     private static final double RELATIVE_TOLERANCE = 0.01;
 
+    private PosteriorSummaryUtils() {
+    }
+
     /**
      * Given a list of posterior samples, returns a PosteriorSummary with central tendency given by the posterior mode
      * (which is estimated using mllib kernel density estimation in {@link KernelDensity},

--- a/src/main/java/org/broadinstitute/hellbender/utils/spark/SparkConverter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/spark/SparkConverter.java
@@ -20,6 +20,10 @@ import java.util.LinkedList;
  */
 public class SparkConverter {
     private static final Logger logger = LogManager.getLogger(SparkConverter.class);
+
+    private SparkConverter() {
+    }
+
     /**
      * Create a distributed matrix given an Apache Commons RealMatrix.
      *

--- a/src/main/java/org/broadinstitute/hellbender/utils/svd/ApacheSingularValueDecomposer.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/svd/ApacheSingularValueDecomposer.java
@@ -9,6 +9,9 @@ import org.broadinstitute.hellbender.utils.Utils;
  */
 class ApacheSingularValueDecomposer {
 
+    private ApacheSingularValueDecomposer() {
+    }
+
     /** Create a SVD instance using Apache Commons Math.
      *
      * @param m matrix that is not {@code null}

--- a/src/main/java/org/broadinstitute/hellbender/utils/svd/OjAlgoSingularValueDecomposer.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/svd/OjAlgoSingularValueDecomposer.java
@@ -11,6 +11,9 @@ class OjAlgoSingularValueDecomposer {
 
     private static final Logger logger = LogManager.getLogger(OjAlgoSingularValueDecomposer.class);
 
+    private OjAlgoSingularValueDecomposer() {
+    }
+
     /**
      * Create a SVD instance using ojAlgo.
      *

--- a/src/main/java/org/broadinstitute/hellbender/utils/svd/SparkSingularValueDecomposer.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/svd/SparkSingularValueDecomposer.java
@@ -19,6 +19,9 @@ class SparkSingularValueDecomposer {
 
     private final static int NUM_SLICES = 60;
 
+    private SparkSingularValueDecomposer() {
+    }
+
     /**
      *  Create a SVD of the given matrix using the given Java Spark Context.
      *

--- a/src/test/java/org/broadinstitute/hellbender/utils/svd/SVDTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/svd/SVDTestUtils.java
@@ -15,6 +15,9 @@ import java.util.List;
  */
 final public class SVDTestUtils {
 
+    private SVDTestUtils() {
+    }
+
     /**
      * Assrt that the given matrix is unitary.
      * @param m


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.