### PR TITLE
Pegging docker to alpha1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/plotting_dump.rda
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,4 +1,4 @@
-# VERSION 0.1 -- very basic setup of an image.
+# VERSION 0.2 -- very basic setup of an image.
 FROM ubuntu:14.04
 
 # Install some tools, including hdfview for HDF5 support and gradle for building the jar
@@ -28,12 +28,6 @@ WORKDIR /root
 # Define default command.
 CMD ["bash"]
 
-RUN wget -N https://downloads.gradle.org/distributions/gradle-2.7-bin.zip
-RUN unzip gradle-2.7-bin.zip
-ENV PATH=/root/gradle-2.7/bin:$PATH
-RUN echo "${PATH}"
-RUN gradle --version
-
 # Installing Java 8.... dockerfile snippet from https://github.com/dockerfile/java/blob/master/oracle-java8/Dockerfile
 RUN \
   echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
@@ -46,7 +40,7 @@ RUN \
 # Define commonly used JAVA_HOME variable
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
-# Added from hellbender public (Getting R setup)
+# Added from GATK4 public (Getting R setup)
 RUN mkdir -p /usr/local/lib/R/
 RUN mkdir -p ~/site-library
 RUN ln -sFv ~/site-library /usr/local/lib/R/site-library
@@ -58,25 +52,31 @@ RUN apt-get install -y --force-yes r-base-core=3.1.3-1trusty
 
 # R setup complete...
 
-# Installing GATK4 protected (hellbender-protected)
-#  This Dockerfile is getting the latest from master branch of gatk4 protected (hellbender-protected)"
-#  This Dockerfile generates a jar file that will work without spark or in spark standalone.  Not on a spark cluster."
-#  Unit tests are NOT being run"
+# Installing GATK4 protected (from repo: gatk-protected)
+#  This Dockerfile is getting the specified tag of gatk4-protected
+#  This Dockerfile generates a jar file that will work without spark or in spark standalone.  Not on a spark cluster.
+#  Unit tests are NOT being run
 
-RUN git clone https://github.com/broadinstitute/hellbender-protected.git
+RUN git clone https://github.com/broadinstitute/gatk-protected.git
 
 # Install custom R packages
-RUN Rscript /root/hellbender-protected/scripts/install_R_packages.R
+RUN Rscript /root/gatk-protected/scripts/install_R_packages.R
 
 # Build the shadowJar
-
-WORKDIR /root/hellbender-protected/
-RUN gradle clean shadowJar
+ENV GATK_PROTECTED_VERSION 1.0.0.0-alpha1.3
+WORKDIR /root/gatk-protected/
+RUN git checkout tags/${GATK_PROTECTED_VERSION}
+RUN ./gradlew clean shadowJar
 
 WORKDIR /root
 
 # Make sure we can see a help message
-RUN ln -sFv /root/hellbender-protected/build/libs/hellbender-protected.jar
-RUN java -jar hellbender-protected.jar -h
+RUN ln -sFv /root/gatk-protected/build/libs/gatk-protected.jar
+RUN java -jar gatk-protected.jar -h
 
 ENV JAVA_LIBRARY_PATH /usr/lib/jni
+
+WORKDIR /root/gatk-protected/
+RUN echo This docker image is running gatk-protected `git describe --tags` > /root/GATK_PROTECTED_VERSION
+
+WORKDIR /root

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -9,7 +9,7 @@ Please see the excellent docker documentation if you need info about docker:  ht
 
 Notes:
 - Image is built on ``ubuntu:14.04``
-- Once image is built, the hellbender-protected.jar (symlink) is found in ``/root`` (i.e. ``$HOME``).
+- Once image is built, the gatk-protected.jar (symlink) is found in ``/root`` (i.e. ``$HOME``).
 - HDF5 jni library is in ``/usr/lib/jni``, since this is the default for Ubuntu 14.04.  This has been added to the ``JAVA_LIBRARY_PATH`` environment variable.
 
 #### Create docker image
@@ -26,5 +26,14 @@ sudo docker run -i -t <image>
 
 # On the docker prompt
 cd hellbender-protected
-gradle test
+./gradlew test
+```
+
+#### See the GATK-protected version from the docker prompt
+```
+# Start a docker image
+sudo docker run -i -t <image>
+
+# In the image prompt:
+cat GATK_PROTECTED_VERSION
 ```

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
@@ -11,6 +11,7 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.hdf5.HDF5File;
 import org.broadinstitute.hellbender.utils.hdf5.HDF5PoN;
+import org.broadinstitute.hellbender.utils.hdf5.HDF5PoNCreator;
 import org.broadinstitute.hellbender.utils.hdf5.PoN;
 import org.broadinstitute.hellbender.utils.tsv.TableColumnCollection;
 import org.broadinstitute.hellbender.utils.tsv.TableUtils;
@@ -111,6 +112,13 @@ public final class NormalizeSomaticReadCounts extends CommandLineProgram {
         Utils.regularReadableUserFile(ponFile);
         try (final HDF5File ponReader = new HDF5File(ponFile)) {
             final PoN pon = new HDF5PoN(ponReader);
+
+            // Test the version of the PoN
+            if (pon.getVersion() < HDF5PoNCreator.CURRENT_PON_VERSION) {
+                logger.warn("The version of the specified PoN (" + pon.getVersion() + ") is older than the latest version " +
+                        "(" + HDF5PoNCreator.CURRENT_PON_VERSION + ").");
+            }
+
             final TargetCollection<? extends BEDFeature> exonCollection = readTargetCollection(targetFile);
             final ReadCountCollection readCountCollection = readInputReadCounts(readCountsFile, exonCollection);
             final TangentNormalizationResult tangentNormalizationResult = TangentNormalizer.tangentNormalizePcov(pon, readCountCollection);


### PR DESCRIPTION
Closes #386 
Closes #501 

**Please note that this pull request assumes that the next release will be alpha-1.3 for the docker image.  It was tested on alpha-1.2**

Also, added warning if the pon version does not match the latest version in NormalizeReadCounts.

Adding warning if the PoN is not the current version in NormalizeSomaicReadCounts.

Setting to be the next version number of gatk-protected.

Adding plotting error dump to gitignore