### PR TITLE
Expose the PairHMM Base Quality Score Threshold in HaplotypeCaller.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerArgumentCollection.java
@@ -7,6 +7,8 @@ import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.Hidden;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.DbsnpArgumentCollection;
 import org.broadinstitute.hellbender.engine.FeatureInput;
+import org.broadinstitute.hellbender.utils.QualityUtils;
+import org.broadinstitute.hellbender.utils.pairhmm.PairHMM;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -130,6 +132,12 @@ public class HaplotypeCallerArgumentCollection extends AssemblyBasedCallerArgume
      */
     @Argument(fullName = "min_base_quality_score", shortName = "mbq", doc = "Minimum base quality required to consider a base for calling", optional = true)
     public byte MIN_BASE_QUALTY_SCORE = 10;
+    
+    /**
+     * Bases with a quality below this threshold will reduced too the minimum usable qualiy score (6).
+     */
+    @Argument(fullName = "base_quality_score_threshold", shortName = "bqst", doc = "Base qualities below this threshold will be reduced to the minimum (" + QualityUtils.MIN_USABLE_Q_SCORE + ")", optional = true)
+    public byte BASE_QUALITY_SCORE_THRESHOLD = PairHMM.BASE_QUALITY_SCORE_THRESHOLD;
 
     /**
      * Reads with mapping qualities below this threshold will be filtered out

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -271,6 +271,10 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
             logger.info("Using global mismapping rate of " + hcArgs.likelihoodArgs.phredScaledGlobalReadMismappingRate + " => " + log10GlobalReadMismappingRate + " in log10 likelihood units");
         }
 
+        if (hcArgs.BASE_QUALITY_SCORE_THRESHOLD < QualityUtils.MIN_USABLE_Q_SCORE) {
+            throw new IllegalArgumentException("BASE_QUALITY_SCORE_THRESHOLD must be greater than or equal to " + QualityUtils.MIN_USABLE_Q_SCORE + " (QualityUtils.MIN_USABLE_Q_SCORE)");
+        }
+
         if ( emitReferenceConfidence() && samplesList.numberOfSamples() != 1 ) {
             throw new UserException.BadArgumentValue("--emitRefConfidence", "Can only be used in single sample mode currently. Use the sample_name argument to run on a single sample out of a multi-sample BAM file.");
         }
@@ -356,7 +360,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
     private ReadLikelihoodCalculationEngine createLikelihoodCalculationEngine() {
         switch ( hcArgs.likelihoodEngineImplementation) {
             case PairHMM:
-                return new PairHMMLikelihoodCalculationEngine((byte) hcArgs.likelihoodArgs.gcpHMM, hcArgs.likelihoodArgs.pairHMM, log10GlobalReadMismappingRate, hcArgs.pcrErrorModel);
+                return new PairHMMLikelihoodCalculationEngine((byte) hcArgs.likelihoodArgs.gcpHMM, hcArgs.likelihoodArgs.pairHMM, log10GlobalReadMismappingRate, hcArgs.pcrErrorModel, hcArgs.BASE_QUALITY_SCORE_THRESHOLD);
             case Random:
                 return new RandomLikelihoodCalculationEngine();
             default:


### PR DESCRIPTION
@akiezun or @eitanbanks 

For some sources of data, the base qualities after recalibration are quite low.  While the data is not ideal, I do still want to include base qualities below Q18 and so I added this option.  I am not sure about how to test this repo, as I ran `./gradlew test` and got many tests that failed that were unrelated to this change, so perhaps you can test this PR and let me know how you did it?