### PR TITLE
Automated docker build with unit tests and automated pushing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/scripts/docker/clone_repo.sh
+/scripts/docker/checkout_tag.sh
+/scripts/docker/GITHUB_TAG
 /plotting_dump.rda
 
 # Mobile Tools for Java (J2ME)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ ${HDF5_DIR}/hdfview_install_linux64.bin
 #  or put the jar location in your ~/.gradle/gradle.properties
 #  custom.jar.dir=${HDF5_DIR}/HDFView/lib
 
-./gradlew -Pcustom.jar.dir=${HDF5_DIR}/HDFView/lib build.gradle shadowJar
+./gradlew -Pcustom.jar.dir=${HDF5_DIR}/HDFView/lib shadowJar
 ```
 
 ### Get ```./gradlew test``` to work.

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,23 +1,47 @@
 # VERSION 0.2 -- very basic setup of an image.
 FROM ubuntu:14.04
 
-# Install some tools, including hdfview for HDF5 support and gradle for building the jar
-RUN apt-get update && apt-get install -y \
+## Not supported by docker-compose
+
+ARG GITHUB_TAG
+ARG GITHUB_DIR=tags/
+
+ENV GITHUB_TAG ${GITHUB_TAG}
+ENV GITHUB_DIR ${GITHUB_DIR}
+
+
+#### Basic image utilities
+RUN apt-get update && \
+     apt-get upgrade -y && \
+     apt-get install -y python && \
+     apt-get install -y python3-pip && \
+     apt-get install -y wget curl unzip gcc python-dev python-setuptools emacs git less lynx hdfview
+##########
+
+# Install some more useful tools
+RUN apt-get install -y \
  aufs-tools \
  automake \
  bedtools \
  btrfs-tools \
  build-essential \
- curl \
  dpkg-sig \
- git \
  iptables \
- hdfview \
  samtools \
- wget \
- curl \
- emacs \
  software-properties-common
+
+#### Specific for google cloud support
+RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip \
+    && unzip google-cloud-sdk.zip \
+    && rm google-cloud-sdk.zip
+
+RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options
+VOLUME ["/root/.config"]
+ENV PATH /google-cloud-sdk/bin:$PATH
+
+RUN yes | gcloud components update
+RUN yes | gcloud components update preview
+###########
 
 # Set environment variables.
 ENV HOME /root
@@ -55,18 +79,14 @@ RUN apt-get install -y --force-yes r-base-core=3.1.3-1trusty
 # Installing GATK4 protected (from repo: gatk-protected)
 #  This Dockerfile is getting the specified tag of gatk4-protected
 #  This Dockerfile generates a jar file that will work without spark or in spark standalone.  Not on a spark cluster.
-#  Unit tests are NOT being run
 
 RUN git clone https://github.com/broadinstitute/gatk-protected.git
 
-# Install custom R packages
-RUN Rscript /root/gatk-protected/scripts/install_R_packages.R
-
-# Build the shadowJar
-ENV GATK_PROTECTED_VERSION 1.0.0.0-alpha1.3
+# Install R dependencies and build the shadowJar
 WORKDIR /root/gatk-protected/
-RUN git checkout tags/${GATK_PROTECTED_VERSION}
-RUN ./gradlew clean shadowJar
+RUN git checkout ${GITHUB_DIR}${GITHUB_TAG}
+RUN Rscript /root/gatk-protected/scripts/install_R_packages.R
+RUN ./gradlew clean compileTestJava shadowJar
 
 WORKDIR /root
 
@@ -76,7 +96,16 @@ RUN java -jar gatk-protected.jar -h
 
 ENV JAVA_LIBRARY_PATH /usr/lib/jni
 
+# Get the cromwell jar file
+RUN wget https://github.com/broadinstitute/cromwell/releases/download/0.19.3/cromwell-0.19.jar
+
+# Install git lfs and get latest big files
 WORKDIR /root/gatk-protected/
+RUN bash scripts/install_git_lfs.sh
+
 RUN echo This docker image is running gatk-protected `git describe --tags` > /root/GATK_PROTECTED_VERSION
+
+# Create a simple unit test runner
+RUN echo "cd /root/gatk-protected/ && ./gradlew test" >/root/run_unit_tests.sh
 
 WORKDIR /root

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -1,5 +1,9 @@
-Docker for GATK4-protected
---------------------------
+Docker for GATK4-protected (Developers)
+--------------------------------------
+
+*This docker script is meant for the GATK4 Broad dev team to create and push docker images.*
+
+*Users should get gatk-protected docker images from dockerhub (https://hub.docker.com/r/broadinstitute/gatk-protected/)*
 
 In this directory lives a simple, *unsupported* docker script.
 
@@ -12,28 +16,71 @@ Notes:
 - Once image is built, the gatk-protected.jar (symlink) is found in ``/root`` (i.e. ``$HOME``).
 - HDF5 jni library is in ``/usr/lib/jni``, since this is the default for Ubuntu 14.04.  This has been added to the ``JAVA_LIBRARY_PATH`` environment variable.
 
-#### Create docker image
+#### Create docker image and push the image to the gatk-protected dockerhub (Seriously, only for Broad GATK4 dev team)
 
-From this directory, run: ``sudo docker build -t my_tag_name/my_tag_version .`` to create your image
+*Please allow 1.5 hours for completion*
+
+```bash
+# REPLACE VALUE OF GITHUB_TAG WITH DESIRED VERSION
+export GITHUB_TAG=1.0.0.0-alpha1.2.1
+
+sudo bash build_docker.sh -e ${GITHUB_TAG} -p
+```
+
+#### Create docker image (do not push to dockerhub)
+
+From this directory, run:
+
+```bash
+# REPLACE VALUE OF GITHUB_TAG WITH DESIRED VERSION
+export GITHUB_TAG=1.0.0.0-alpha1.2.1
+
+sudo bash build_docker.sh -e ${GITHUB_TAG}
+
+```
+
+#### Create docker image from a github hash (pushing to dockerhub prohibited)
+
+From this directory, run:
+
+```bash
+# REPLACE VALUE OF GITHUB_TAG WITH DESIRED VERSION
+export GITHUB_HASH=e454ac88c7791c0f8b385b3e82138ec52c61ef48
+
+sudo bash build_docker.sh -e ${GITHUB_HASH} -s
+```
 
 #### Run gradle test
 
+*Note that the unit tests are run during a build of the Dockerfile*
+
 Currently, this is a bit manual.
 
-```
-# bash is the default command.
-sudo docker run -i -t <image> 
+```bash
+# bash is the default command for the docker image.
+sudo docker pull broadinstitute/gatk-protected
+sudo docker run -i -t broadinstitute/gatk-protected:latest
 
 # On the docker prompt
-cd hellbender-protected
+cd /root/gatk-protected
 ./gradlew test
+
+# To leave the docker prompt:
+exit
 ```
 
 #### See the GATK-protected version from the docker prompt
-```
+```bash
 # Start a docker image
-sudo docker run -i -t <image>
+sudo docker pull broadinstitute/gatk-protected
+sudo docker run -i -t broadinstitute/gatk-protected:latest
 
 # In the image prompt:
 cat GATK_PROTECTED_VERSION
+```
+
+#### Delete all containers
+```bash
+# Credit:  http://stackoverflow.com/questions/17236796/how-to-remove-old-docker-containers
+sudo docker rm `sudo docker ps --no-trunc -aq`
 ```

--- a/scripts/docker/build_docker.sh
+++ b/scripts/docker/build_docker.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Have script stop if there is an error
+set -e
+
+REPO=broadinstitute
+PROJECT=gatk-protected
+REPO_PRJ=${REPO}/${PROJECT}
+
+#################################################
+# Parsing arguments
+#################################################
+while getopts "e:pslr" option; do
+	case "$option" in
+		e) GITHUB_TAG="$OPTARG" ;;
+		p) IS_PUSH=true ;;
+		s) IS_HASH=true ;;
+		l) IS_NOT_LATEST=true ;;
+		r) IS_NOT_REMOVE_UNIT_TEST_CONTAINER=true ;;
+	esac
+done
+
+if [ -z "$GITHUB_TAG" ]; then
+	printf "Option -e requires an argument.\n \
+Usage: %s: -e <GITHUB_TAG> [-psl] \n \
+where <GITHUB_TAG> is the github tag (or hash when -s is used) to use in building the docker image\n \
+(e.g. bash build_docker.sh -e 1.0.0.0-alpha1.2.1)\n \
+Optional arguments:  \n \
+-p \t (DEV) push image to docker hub once complete.  This will use the GITHUB_TAG in dockerhub as well. \n \
+\t\t Unless -l is specified, this will also push this image to the 'latest' tag. \n \
+-s \t The GITHUB_TAG (-e parameter) is actually a github hash, not tag.  git hashes cannot be pushed as latest, so -l is implied.  \n \
+-l \t Do not also push the image to the 'latest' tag. \n \
+-r \t Do not remove the unit test docker container.  This is useful for debugging failing unit tests. \n" $0
+	exit 1
+fi
+
+# Make sure sudo or root was used.
+if [ "$(whoami)" != "root" ]; then
+	echo "You must have superuser privileges (through sudo or root user) to run this script"
+	exit 1
+fi
+
+# -z is like "not -n"
+if [ -z ${IS_NOT_LATEST} ] && [ -n "${IS_HASH}" ] && [ -n "${IS_PUSH}" ]; then
+	echo -e "\n##################"
+	echo " WARNING:  Refusing to push a hash as latest to dockerhub. "
+	echo "##################"
+	IS_NOT_LATEST=true
+fi
+
+# Output the parameters
+echo -e "\n"
+echo -e "github tag/hash: ${GITHUB_TAG}"
+echo -e "docker hub repo, project, and tag: ${REPO_PRJ}:${GITHUB_TAG}\n\n"
+echo "Other options (Blank is false)"
+echo "---------------"
+echo "This is a git hash: ${IS_HASH}"
+echo "Push to dockerhub: ${IS_PUSH}"
+echo "Do NOT remove the unit test container: ${IS_NOT_REMOVE_UNIT_TEST_CONTAINER}"
+echo -e "Do NOT make this the default docker image: ${IS_NOT_LATEST}\n\n"
+
+# Login to dockerhub
+if [ -n "${IS_PUSH}" ]; then
+	echo "Please login to dockerhub"
+	docker login
+fi
+
+# Build
+echo "Building image to tag ${REPO_PRJ}:${GITHUB_TAG}..."
+if [ -n "${IS_HASH}" ]; then
+	docker build -t ${REPO_PRJ}:${GITHUB_TAG} --build-arg GITHUB_TAG=${GITHUB_TAG} --build-arg GITHUB_DIR=\  .
+else
+	docker build -t ${REPO_PRJ}:${GITHUB_TAG} --build-arg GITHUB_TAG=${GITHUB_TAG} .
+fi
+
+# Run unit tests
+echo "Running unit tests..."
+REMOVE_CONTAINER_STRING=" --rm "
+if [ -n "${IS_NOT_REMOVE_UNIT_TEST_CONTAINER}" ] ; then
+	REMOVE_CONTAINER_STRING=" "
+fi
+echo docker run ${REMOVE_CONTAINER_STRING} -t ${REPO_PRJ}:${GITHUB_TAG} bash /root/run_unit_tests.sh
+docker run ${REMOVE_CONTAINER_STRING} -t ${REPO_PRJ}:${GITHUB_TAG} bash /root/run_unit_tests.sh
+echo " Unit tests passed..."
+
+## Push
+if [ -n "${IS_PUSH}" ]; then
+
+	docker push ${REPO_PRJ}:${GITHUB_TAG}
+
+	if [ -z "${IS_NOT_LATEST}" ] && [ -z "${IS_HASH}" ] ; then
+		docker build -t ${REPO_PRJ}:latest --build-arg GITHUB_TAG=${GITHUB_TAG} .
+		docker push ${REPO_PRJ}:latest
+	fi
+
+else
+	echo "Not pushing to dockerhub"
+fi
+

--- a/scripts/install_git_lfs.sh
+++ b/scripts/install_git_lfs.sh
@@ -9,8 +9,8 @@ wget -qO- $GIT_LFS_LINK | tar xvz
 echo "ls"
 ls
 
-echo "resetting travis remote"
-git remote set-url origin "https://github.com/broadinstitute/gatk.git"
+#echo "resetting travis remote"
+#git remote set-url origin "https://github.com/broadinstitute/gatk.git"
 
 echo "git lfs install"
 GIT_TRACE=1 $GIT_LFS install


### PR DESCRIPTION
Closes #575 
Closes #590 

Build a docker image based on a github tag in the github gatk-protected repo (``build_docker.sh``).

### Notes
- Supports automated pushing to ``https://hub.docker.com/r/broadinstitute/gatk-protected/``
- Insists on unit testing on the docker image before pushing
- Supports git hashes and pushing those to dockerhub
- Disallows git hashes posted as ``latest`` tag in dockerhub
- Can build images without pushing to docker hub
- Building an image takes a long time (over one hour)
- Requires sudo to run and checks
- Basic use cases documented in README
- Running of unit tests is *not* part of the ``docker build ...  ``
- Will automatically remove the docker container after unit tests complete, by default.  This can be disabled for debugging of failed unit tests.
