### PR TITLE
fix hdf5 test failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,8 +79,8 @@ check.dependsOn installDist
 dependencies {
     compile files("${System.properties['java.home']}/../lib/tools.jar")
     compile 'org.broadinstitute:gatk:4.alpha.1-199-g8377acb-20160713.142718-1'
-    compile 'org.broadinstitute:hdf5-java-bindings:1.0.0-hdf5_2.11.0'
-
+    compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
+    
     testCompile 'org.testng:testng:6.8.8'
 }
 


### PR DESCRIPTION
This fixes it for me in my docker image.  @LeeTL1220 Could you test this.  Don't merge this yet, I'd like to wait until we merge https://github.com/broadinstitute/hdf5-java-bindings/pull/6 and have a non-snapshot version.