### PR TITLE
Fixed travis evaluation of the acnv workflow

### DIFF
--- a/scripts/acnv_cromwell_tests/case_gatk_acnv_workflow_exome.json
+++ b/scripts/acnv_cromwell_tests/case_gatk_acnv_workflow_exome.json
@@ -31,5 +31,7 @@
   "case_gatk_acnv_workflow.seg_param_trim": "0.025",
   "case_gatk_acnv_workflow.seg_param_undoSplits": "NONE",
   "case_gatk_acnv_workflow.seg_param_undoPrune": "0.05",
-  "case_gatk_acnv_workflow.seg_param_undoSD": "3"
+  "case_gatk_acnv_workflow.seg_param_undoSD": "3",
+  "case_gatk_acnv_workflow.stringency": "30",
+  "case_gatk_acnv_workflow.read_depth_threshold": "15"
 }

--- a/scripts/acnv_cromwell_tests/case_gatk_acnv_workflow_wgs.json
+++ b/scripts/acnv_cromwell_tests/case_gatk_acnv_workflow_wgs.json
@@ -31,5 +31,7 @@
   "case_gatk_acnv_workflow.seg_param_trim": "0.025",
   "case_gatk_acnv_workflow.seg_param_undoSplits": "NONE",
   "case_gatk_acnv_workflow.seg_param_undoPrune": "0.05",
-  "case_gatk_acnv_workflow.seg_param_undoSD": "3"
+  "case_gatk_acnv_workflow.seg_param_undoSD": "3",
+  "case_gatk_acnv_workflow.stringency": "0.1",
+  "case_gatk_acnv_workflow.read_depth_threshold": "1"
 }

--- a/scripts/acnv_cromwell_tests/pon_gatk_workflow_exome.json
+++ b/scripts/acnv_cromwell_tests/pon_gatk_workflow_exome.json
@@ -1,6 +1,7 @@
 {
   "pon_gatk_workflow.disable_sequence_dictionary_validation": "true",
   "pon_gatk_workflow.isWGS": "false",
+  "pon_gatk_workflow.noQC": "true",
   "pon_gatk_workflow.max_open_files": "100",
   "pon_gatk_workflow.wgsBinSize": "10000",
   "pon_gatk_workflow.enable_gc_correction": "true",

--- a/scripts/acnv_cromwell_tests/pon_gatk_workflow_wgs.json
+++ b/scripts/acnv_cromwell_tests/pon_gatk_workflow_wgs.json
@@ -1,6 +1,7 @@
 {
   "pon_gatk_workflow.disable_sequence_dictionary_validation": "true",
   "pon_gatk_workflow.isWGS": "true",
+  "pon_gatk_workflow.noQC": "true",
   "pon_gatk_workflow.max_open_files": "100",
   "pon_gatk_workflow.wgsBinSize": "10000",
   "pon_gatk_workflow.enable_gc_correction": "true",

--- a/scripts/acnv_cromwell_tests/run_acnv_pipelines.sh
+++ b/scripts/acnv_cromwell_tests/run_acnv_pipelines.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -l
-
+set -e
 #cd in the directory of the script in order to use relative paths
 script_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
 cd "$script_path"

--- a/scripts/wdl/README.md
+++ b/scripts/wdl/README.md
@@ -19,7 +19,8 @@ Fields marked as Advanced almost never require a user to adjust the default valu
 Reference used must be the same between PoN and case samples.
 
 - ``pon_gatk_workflow.disable_sequence_dictionary_validation`` -- (Advanced) "true".  For end users, the value should not matter.  Developers leave this as true for debugging on smaller references.
-- ``pon_gatk_workflow.isWGS`` -- Change to "true"" if running WGS samples
+- ``pon_gatk_workflow.isWGS`` -- Change to "true" if running WGS samples
+- ``pon_gatk_workflow.noQC`` -- (Advanced) Change to "true" to disable quality control of samples and targets for PoN creation
 - ``pon_gatk_workflow.max_open_files`` -- (Advanced) "100",  Maximum number of files to combine simultaneously while combining read counts
 - ``pon_gatk_workflow.wgsBinSize`` --  Size of bins (in bp) for WGS read counts CLI.  *This must be the same values used for all case samples*.  Ignored if not running WGS.
 - ``pon_gatk_workflow.enable_gc_correction`` --  "true" is recommended,  This is a true/false option change to false to bypass GC bias correction step.  All case samples must be run with the same value as used in PoN creation.
@@ -59,6 +60,8 @@ Reference used must be the same between PoN and case samples.
 - ``case_gatk_acnv_workflow.enable_gc_correction`` -- "true" is recommended. This is a true/false option change to false to bypass GC bias correction step.  *This must be the same as was used to generate the PoN*
 - ``case_gatk_acnv_workflow.isWGS`` -- Change to true if running WGS samples.  You should also change ``case_gatk_acnv_workflow.seg_param_undoSplits`` and ``case_gatk_acnv_workflow.seg_param_undoSD`` to reduce (not eliminate) hyper-segmentation.
 - ``case_gatk_acnv_workflow.wgsBinSize`` -- "10000" is recommended.  Size of bins (in bp) for WGS read counts CLI.  *This must be the same as was used to generate the PoN*.  Ignored if not running WGS.
+- ``case_gatk_acnv_workflow.stringency`` -- (Advanced) ``GetHetBayesianCoverage`` parameter, default=30. End users should leave this value unchanged.
+- ``case_gatk_acnv_workflow.read_depth_threshold`` -- (Advanced) ``GetHetBayesianCoverage`` parameter, default=15. End users should leave this value unchanged.
 
 *For ``PerformSegmentation`` parameters, see pgs. 11-12 of https://bioconductor.org/packages/release/bioc/manuals/DNAcopy/man/DNAcopy.pdf*
 - ``case_gatk_acnv_workflow.seg_param_alpha`` -- (Advanced)  ``PerformSegmentation`` parameter, default=0.01

--- a/scripts/wdl/case_gatk_acnv_workflow.wdl
+++ b/scripts/wdl/case_gatk_acnv_workflow.wdl
@@ -52,6 +52,10 @@ workflow case_gatk_acnv_workflow {
     Float seg_param_undoPrune
     Int seg_param_undoSD
 
+    # Input parameters of GetBayesianHetCoverage tool
+    Float stringency
+    Int read_depth_threshold
+
     # Workflow output directories and options
     String plots_dir
     String call_cnloh_dir
@@ -125,7 +129,7 @@ workflow case_gatk_acnv_workflow {
 
     call NormalizeSomaticReadCounts as TumorNormalizeSomaticReadCounts {
       input:
-          entity_id=row[0], 
+          entity_id=row[0],
           coverage_file=TumorCorrectGCBias.gatk_cnv_coverage_file_gcbias,
           padded_target_file=TumorWholeGenomeCoverage.gatk_target_file,
           pon=PoN,
@@ -174,8 +178,9 @@ workflow case_gatk_acnv_workflow {
           normal_bam=row[4],
           normal_bam_idx=row[5],
           common_snp_list=common_snp_list,
-          mem=4,
-          stringency=30
+          stringency=stringency,
+          read_depth_threshold=read_depth_threshold,
+          mem=4
     }
 
     call AllelicCNV {
@@ -585,13 +590,15 @@ task BayesianHetPulldownPaired {
     File normal_bam
     File normal_bam_idx
     File common_snp_list
+    Float stringency
+    Int read_depth_threshold
     Int mem
-    Int stringency
 
     command {
         java -Xmx${mem}g -jar ${gatk_jar} GetBayesianHetCoverage --reference ${ref_fasta} \
          --normal ${normal_bam} --tumor ${tumor_bam} --snpIntervals ${common_snp_list} \
-         --normalHets ${entity_id_normal}.normal.hets.tsv --tumorHets ${entity_id_tumor}.tumor.hets.tsv --hetCallingStringency ${stringency} \
+         --normalHets ${entity_id_normal}.normal.hets.tsv --tumorHets ${entity_id_tumor}.tumor.hets.tsv \
+         --hetCallingStringency ${stringency} --readDepthThreshold ${read_depth_threshold} \
          --help false --version false --verbosity INFO --QUIET false --VALIDATION_STRINGENCY LENIENT
     }
 

--- a/scripts/wdl/case_gatk_acnv_workflow_template.json
+++ b/scripts/wdl/case_gatk_acnv_workflow_template.json
@@ -31,5 +31,7 @@
   "case_gatk_acnv_workflow.seg_param_trim": "0.025", 
   "case_gatk_acnv_workflow.seg_param_undoSplits": "$__UNDO_SPLITS__", 
   "case_gatk_acnv_workflow.seg_param_undoPrune": "0.05", 
-  "case_gatk_acnv_workflow.seg_param_undoSD": "$__UNDO_SD__" 
+  "case_gatk_acnv_workflow.seg_param_undoSD": "$__UNDO_SD__",
+  "case_gatk_acnv_workflow.stringency": "30",
+  "case_gatk_acnv_workflow.read_depth_threshold": "15"
 }

--- a/scripts/wdl/pon_gatk_workflow.wdl
+++ b/scripts/wdl/pon_gatk_workflow.wdl
@@ -40,6 +40,7 @@ workflow pon_gatk_workflow {
     String combined_entity_id = "combined_read_counts"
     Int max_open_files
     Int wgsBinSize
+    Boolean noQC
 
     # PoN name
     String pon_entity_id
@@ -132,6 +133,7 @@ workflow pon_gatk_workflow {
         pon_entity_id=pon_entity_id,
         read_counts_file=CorrectGCBias.coverage_file_gcbias_corrected,
         gatk_jar=gatk_jar,
+        noQC=noQC,
         mem=4
   }
 }
@@ -339,11 +341,15 @@ task CreatePanelOfNormals {
     String pon_entity_id
     File read_counts_file
     File gatk_jar
+    Boolean noQC
     Int mem
 
     command {
+        # If there are no removed samples the output file still needs to be created
+        touch "${pon_entity_id}.pon.removed_samples.txt"
         java -Xmx${mem}g -jar ${gatk_jar} CreatePanelOfNormals --extremeColumnMedianCountPercentileThreshold 2.5 \
-         --truncatePercentileThreshold 0.1 --input ${read_counts_file} --output ${pon_entity_id}.pon
+         --truncatePercentileThreshold 0.1 --input ${read_counts_file} --output ${pon_entity_id}.pon \
+         --noQC ${noQC}
     }
 
     output {

--- a/scripts/wdl/pon_gatk_workflow_template.json
+++ b/scripts/wdl/pon_gatk_workflow_template.json
@@ -1,6 +1,7 @@
 {
   "pon_gatk_workflow.disable_sequence_dictionary_validation": "true",
   "pon_gatk_workflow.isWGS": "false", 
+  "pon_gatk_workflow.noQC": "false",
   "pon_gatk_workflow.max_open_files": "1000",
   "pon_gatk_workflow.wgsBinSize": "10000",  
   "pon_gatk_workflow.enable_gc_correction": "true", 


### PR DESCRIPTION
Closes #680 
Travis.yml wasn't properly evaluating the tests of the acnv workflows, as it did not fail if one of the workflows fails. 
Also I disabled QC for Travis tests since the CreatePanelOfNormals threw out all samples on the test data. 
