### PR TITLE
Rev gatk-public dependency to 4.alpha.2-63-g13f88ae-20161016.062553-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ check.dependsOn installDist
 
 dependencies {
     compile files("${System.properties['java.home']}/../lib/tools.jar")
-    compile 'org.broadinstitute:gatk:4.alpha.2-61-gcdc484c-20160929.184342-1'
+    compile 'org.broadinstitute:gatk:4.alpha.2-63-g13f88ae-20161016.062553-1'
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
     
     testCompile 'org.testng:testng:6.8.8'


### PR DESCRIPTION
This brings in the ploidy bug fix for the HaplotypeCaller