### PR TITLE
Fix regression in HaplotypeCaller with shard boundary check

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -14,6 +14,7 @@ import org.broadinstitute.hellbender.engine.*;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -238,7 +239,7 @@ public final class HaplotypeCaller extends AssemblyRegionWalker {
         hcEngine.callRegion(region, featureContext).stream()
                 // Only include calls that start within the current read shard (as opposed to the padded regions around it).
                 // This is critical to avoid duplicating events that span shard boundaries!
-                .filter(call -> getCurrentReadShardBounds().contains(call))
+                .filter(call -> getCurrentReadShardBounds().contains(new SimpleInterval(call.getContig(), call.getStart(), call.getStart())))
                 .forEach(vcfWriter::add);
     }
 


### PR DESCRIPTION
Somehow during refactoring, the line in the HaplotypeCaller that checks
whether an event starts in the current shard got changed to instead check
that the event is completely contained in the current shard. This means that
events spanning shard boundaries would be dropped completely.
