### PR TITLE
connect PairHMMNativeArguments args to HaplotypeCaller

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ check.dependsOn installDist
 
 dependencies {
     compile files("${System.properties['java.home']}/../lib/tools.jar")
-    compile 'org.broadinstitute:gatk:4.alpha.2-95-g64661b5-20161114.160836-1'
+    compile 'org.broadinstitute:gatk:4.alpha.2-110-ga71331d-20161129.223512-1'
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
 
     testCompile 'org.testng:testng:6.8.8'

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -168,7 +168,7 @@ public class AssemblyBasedCallerUtils {
 
         switch ( likelihoodArgs.likelihoodEngineImplementation) {
             case PairHMM:
-                return new PairHMMLikelihoodCalculationEngine((byte) likelihoodArgs.gcpHMM, likelihoodArgs.pairHMM, log10GlobalReadMismappingRate, likelihoodArgs.pcrErrorModel, likelihoodArgs.BASE_QUALITY_SCORE_THRESHOLD);
+                return new PairHMMLikelihoodCalculationEngine((byte) likelihoodArgs.gcpHMM, likelihoodArgs.pairHMMNativeArgs.getPairHMMArgs(), likelihoodArgs.pairHMM, log10GlobalReadMismappingRate, likelihoodArgs.pcrErrorModel, likelihoodArgs.BASE_QUALITY_SCORE_THRESHOLD);
             case Random:
                 return new RandomLikelihoodCalculationEngine();
             default:

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/LikelihoodEngineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/LikelihoodEngineArgumentCollection.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 
 import org.broadinstitute.hellbender.cmdline.Advanced;
 import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.Hidden;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.pairhmm.PairHMM;
@@ -65,5 +66,8 @@ public final class LikelihoodEngineArgumentCollection implements Serializable {
     @Advanced
     @Argument(fullName="phredScaledGlobalReadMismappingRate", shortName="globalMAPQ", doc="The global assumed mismapping rate for reads", optional = true)
     public int phredScaledGlobalReadMismappingRate = 45;
+
+    @ArgumentCollection
+    public PairHMMNativeArgumentCollection pairHMMNativeArgs = new PairHMMNativeArgumentCollection();
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngine.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.SAMUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.QualityUtils;
@@ -99,10 +100,11 @@ public final class PairHMMLikelihoodCalculationEngine implements ReadLikelihoodC
      * @param pcrErrorModel model to correct for PCR indel artifacts
      */
     public PairHMMLikelihoodCalculationEngine(final byte constantGCP,
+                                              final PairHMMNativeArguments arguments,
                                               final PairHMM.Implementation hmmType,
                                               final double log10globalReadMismappingRate,
                                               final PCRErrorModel pcrErrorModel) {
-        this( constantGCP, hmmType, log10globalReadMismappingRate, pcrErrorModel, PairHMM.BASE_QUALITY_SCORE_THRESHOLD );
+        this( constantGCP, arguments, hmmType, log10globalReadMismappingRate, pcrErrorModel, PairHMM.BASE_QUALITY_SCORE_THRESHOLD );
     }
 
     /**
@@ -123,6 +125,7 @@ public final class PairHMMLikelihoodCalculationEngine implements ReadLikelihoodC
      *                                  quality.
      */
     public PairHMMLikelihoodCalculationEngine(final byte constantGCP,
+                                              final PairHMMNativeArguments arguments,
                                               final PairHMM.Implementation hmmType,
                                               final double log10globalReadMismappingRate,
                                               final PCRErrorModel pcrErrorModel,
@@ -138,7 +141,7 @@ public final class PairHMMLikelihoodCalculationEngine implements ReadLikelihoodC
         this.constantGCP = constantGCP;
         this.log10globalReadMismappingRate = log10globalReadMismappingRate;
         this.pcrErrorModel = pcrErrorModel;
-        this.pairHMM = hmmType.makeNewHMM();
+        this.pairHMM = hmmType.makeNewHMM(arguments);
 
         initializePCRErrorModel();
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMNativeArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMNativeArgumentCollection.java
@@ -9,7 +9,7 @@ import org.broadinstitute.hellbender.cmdline.Argument;
 public class PairHMMNativeArgumentCollection {
 
     @Argument(fullName = "nativePairHmmThreads", shortName = "threads", doc="How many threads should a native pairHMM implementation use", optional = true)
-    private int pairHmmNativeThreads = 1;
+    private int pairHmmNativeThreads = 2;
 
     @Argument(fullName = "useDoublePrecision", shortName = "useDoublePrecision", doc="use double precision in the native pairHmm. " +
             "This is slower but matches the java implementation better", optional = true)

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMNativeArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMNativeArgumentCollection.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
+
+import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
+import org.broadinstitute.hellbender.cmdline.Argument;
+
+/**
+ * Arguments for native PairHMM implementations
+ */
+public class PairHMMNativeArgumentCollection {
+
+    @Argument(fullName = "nativePairHmmThreads", shortName = "threads", doc="How many threads should a native pairHMM implementation use", optional = true)
+    private int pairHmmNativeThreads = 1;
+
+    @Argument(fullName = "useDoublePrecision", shortName = "useDoublePrecision", doc="use double precision in the native pairHmm. " +
+            "This is slower but matches the java implementation better", optional = true)
+    private boolean useDoublePrecision = false;
+
+    public PairHMMNativeArguments getPairHMMArgs(){
+        final PairHMMNativeArguments args = new PairHMMNativeArguments();
+        args.maxNumberOfThreads = pairHmmNativeThreads;
+        args.useDoublePrecision = useDoublePrecision;
+        return args;
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngineUnitTest.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import htsjdk.samtools.SAMUtils;
 import htsjdk.samtools.TextCigarCodec;
 import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.genotyper.IndexedSampleList;
@@ -118,7 +119,7 @@ public final class PairHMMLikelihoodCalculationEngineUnitTest extends BaseTest {
     @Test(dataProvider = "PcrErrorModelTestProvider", enabled = true)
     public void createPcrErrorModelTest(final String repeat, final int repeatLength) {
 
-        final PairHMMLikelihoodCalculationEngine engine = new PairHMMLikelihoodCalculationEngine((byte)0,
+        final PairHMMLikelihoodCalculationEngine engine = new PairHMMLikelihoodCalculationEngine((byte)0, new PairHMMNativeArguments(),
                 PairHMM.Implementation.ORIGINAL, 0.0,
                 PairHMMLikelihoodCalculationEngine.PCRErrorModel.CONSERVATIVE);
 
@@ -165,7 +166,7 @@ public final class PairHMMLikelihoodCalculationEngineUnitTest extends BaseTest {
 
         PairHMMLikelihoodCalculationEngine.writeLikelihoodsToFile = true;
 
-        final ReadLikelihoodCalculationEngine lce = new PairHMMLikelihoodCalculationEngine((byte) SAMUtils.MAX_PHRED_SCORE,
+        final ReadLikelihoodCalculationEngine lce = new PairHMMLikelihoodCalculationEngine((byte) SAMUtils.MAX_PHRED_SCORE, new PairHMMNativeArguments(),
                 PairHMM.Implementation.LOGLESS_CACHING, MathUtils.logToLog10(QualityUtils.qualToErrorProbLog10(LEAC.phredScaledGlobalReadMismappingRate)),
                 PairHMMLikelihoodCalculationEngine.PCRErrorModel.CONSERVATIVE);
 


### PR DESCRIPTION
Adding a new `PairHmmNativeArgumentCollection` to `LikelihoodArgumentCollection`.  This allows the precision and number of threads to use for PairHmms to be passed in from the command line.