### PR TITLE
Refactoring to prepare Mutect2 for model improvements

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -43,7 +43,7 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
      * A panel of normals can be a useful (optional) input to help filter out commonly seen sequencing noise that may appear as low allele-fraction somatic variants.
      */
     @Argument(fullName="normal_panel", shortName = "PON", doc="VCF file of sites observed in normal", optional = true)
-    public List<FeatureInput<VariantContext>> normalPanelFeatureInput = Collections.emptyList();
+    public FeatureInput<VariantContext> normalPanelFeatureInput;
 
     /**
      * Artifact detection mode is used to prepare a panel of normals. This maintains the specified tumor LOD threshold,
@@ -58,12 +58,6 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
      */
     @Argument(fullName = "initial_tumor_lod", optional = true, doc = "Initial LOD threshold for calling tumor variant")
     public double INITIAL_TUMOR_LOD_THRESHOLD = 4.0;
-
-    /**
-     * This is the LOD threshold corresponding to the minimum amount of reference evidence in the normal for a variant to be considered somatic and emitted in the VCF
-     */
-    @Argument(fullName = "initial_normal_lod", optional = true, doc = "Initial LOD threshold for calling normal variant")
-    public double INITIAL_NORMAL_LOD_THRESHOLD = 0.5;
 
     /**
      * Only variants with tumor LODs exceeding this threshold can pass filtering.
@@ -83,27 +77,6 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
      */
     @Argument(fullName = "dbsnp_normal_lod", optional = true, doc = "LOD threshold for calling normal non-variant at dbsnp sites")
     public double NORMAL_DBSNP_LOD_THRESHOLD = 5.5;
-
-    /**
-     * This argument is used for the internal "alt_allele_in_normal" filter.
-     * A variant will PASS the filter if the value tested is lower or equal to the threshold value. It will FAIL the filter if the value tested is greater than the max threshold value.
-     **/
-    @Argument(fullName = "max_alt_alleles_in_normal_count", optional = true, doc="Threshold for maximum alternate allele counts in normal")
-    public int MAX_ALT_ALLELES_IN_NORMAL_COUNT = 1;
-
-    /**
-     * This argument is used for the internal "alt_allele_in_normal" filter.
-     * A variant will PASS the filter if the value tested is lower or equal to the threshold value. It will FAIL the filter if the value tested is greater than the max threshold value.
-     */
-    @Argument(fullName = "max_alt_alleles_in_normal_qscore_sum", optional = true, doc="Threshold for maximum alternate allele quality score sum in normal")
-    public int MAX_ALT_ALLELES_IN_NORMAL_QSCORE_SUM = 20;
-
-    /**
-     * This argument is used for the internal "alt_allele_in_normal" filter.
-     * A variant will PASS the filter if the value tested is lower or equal to the threshold value. It will FAIL the filter if the value tested is greater than the max threshold value.
-     */
-    @Argument(fullName = "max_alt_allele_in_normal_fraction", optional = true, doc="Threshold for maximum alternate allele fraction in normal")
-    public double MAX_ALT_ALLELE_IN_NORMAL_FRACTION = 0.03;
 
     /**
      * This argument is used for the M1-style strand bias filter

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2FilteringEngine.java
@@ -1,22 +1,24 @@
 package org.broadinstitute.hellbender.tools.walkers.mutect;
 
 import htsjdk.variant.variantcontext.VariantContext;
-import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.utils.variant.GATKVCFConstants;
 
-import java.util.Collection;
+import java.util.*;
 
 /**
  * Created by davidben on 9/15/16.
  */
 public class Mutect2FilteringEngine {
-    final M2ArgumentCollection MTAC;
 
-    public Mutect2FilteringEngine(final M2ArgumentCollection MTAC) {
-        this.MTAC = MTAC;
+    private Mutect2FilteringEngine() { }
+
+    private static void applyTriallelicFilter(final VariantContext vc, final Collection<String> filters) {
+        if (vc.getNAlleles() > 2) {
+            filters.add(GATKVCFConstants.TRIALLELIC_SITE_FILTER_NAME);
+        }
     }
 
-    public void applySTRFilter(final VariantContext vc, final Collection<String> filters) {
+    private static void applySTRFilter(final VariantContext vc, final Collection<String> filters) {
         // STR contractions, such as ACTACTACT -> ACTACT, are overwhelmingly false positives so we hard filter by default
         if (vc.isIndel()) {
             final int[] rpa = vc.getAttributeAsList(GATKVCFConstants.REPEATS_PER_ALLELE_KEY).stream()
@@ -33,7 +35,7 @@ public class Mutect2FilteringEngine {
         }
     }
 
-    public void applyClusteredReadPositionFilter(final VariantContext vc, final Collection<String> filters) {
+    private static void applyClusteredReadPositionFilter(final M2ArgumentCollection MTAC, final VariantContext vc, final Collection<String> filters) {
         if (MTAC.ENABLE_CLUSTERED_READ_POSITION_FILTER) {
             final Double tumorFwdPosMedian = (Double) vc.getAttribute(GATKVCFConstants.MEDIAN_LEFT_OFFSET_KEY);
             final Double tumorRevPosMedian = (Double) vc.getAttribute(GATKVCFConstants.MEDIAN_RIGHT_OFFSET_KEY);
@@ -46,15 +48,63 @@ public class Mutect2FilteringEngine {
         }
     }
 
-    public void applyPanelOfNormalsFilter(final VariantContext vc, final Collection<String> filters, final FeatureContext featureContext) {
-        //TODO: verify that vc.getStart() is the right second argument to use here
-        final Collection<VariantContext> panelOfNormalsVC = featureContext.getValues(MTAC.normalPanelFeatureInput, vc.getStart());
-
-        // Note that we're filtering even if the alleles are different.  This is due to the different roles
-        // of the matched normal, which says which alternate *alleles* are germline events,
-        // and the panel of normals, which says which *sites* are generally noisy and not to be trusted.
-        if (!panelOfNormalsVC.isEmpty()) {
+    private static void applyPanelOfNormalsFilter(final M2ArgumentCollection MTAC, final VariantContext vc, final Collection<String> filters) {
+        final boolean siteInPoN = vc.hasAttribute(SomaticGenotypingEngine.IN_PON_VCF_ATTRIBUTE);
+        if (siteInPoN) {
             filters.add(GATKVCFConstants.PON_FILTER_NAME);
         }
     }
+
+    private static void applyGermlineVariantFilter(final M2ArgumentCollection MTAC, final VariantContext vc, final Collection<String> filters) {
+        if (!vc.hasAttribute(GATKVCFConstants.NORMAL_LOD_KEY)) {
+            return;
+        }
+        final boolean siteInCosmic = vc.hasAttribute(SomaticGenotypingEngine.IN_COSMIC_VCF_ATTRIBUTE);
+        final boolean siteInDbsnp = vc.hasAttribute(SomaticGenotypingEngine.IN_DBSNP_VCF_ATTRIBUTE);
+        if (siteInDbsnp && !siteInCosmic ) {
+            final double normalLod = vc.getAttributeAsDouble(GATKVCFConstants.NORMAL_LOD_KEY, 0.0);
+            if (normalLod < MTAC.NORMAL_DBSNP_LOD_THRESHOLD) {
+                filters.add(GATKVCFConstants.GERMLINE_RISK_FILTER_NAME);
+            }
+        }
+    }
+
+    private static void applyStrandBiasFilter(final M2ArgumentCollection MTAC, final VariantContext vc, final Collection<String> filters) {
+        if (MTAC.ENABLE_STRAND_ARTIFACT_FILTER) {
+            if (vc.hasAttribute(GATKVCFConstants.TLOD_FWD_KEY) && vc.hasAttribute(GATKVCFConstants.TLOD_REV_KEY)
+                    && vc.hasAttribute(GATKVCFConstants.TUMOR_SB_POWER_FWD_KEY) && vc.hasAttribute(GATKVCFConstants.TUMOR_SB_POWER_REV_KEY)) {
+                final double forwardLod = vc.getAttributeAsDouble(GATKVCFConstants.TLOD_FWD_KEY, 0.0);
+                final double reverseLod = vc.getAttributeAsDouble(GATKVCFConstants.TLOD_REV_KEY, 0.0);
+                final double forwardPower = vc.getAttributeAsDouble(GATKVCFConstants.TUMOR_SB_POWER_FWD_KEY, 0.0);
+                final double reversePower = vc.getAttributeAsDouble(GATKVCFConstants.TUMOR_SB_POWER_REV_KEY, 0.0);
+                if ((forwardPower > MTAC.STRAND_ARTIFACT_POWER_THRESHOLD && forwardLod < MTAC.STRAND_ARTIFACT_LOD_THRESHOLD) ||
+                        (reversePower > MTAC.STRAND_ARTIFACT_POWER_THRESHOLD && reverseLod < MTAC.STRAND_ARTIFACT_LOD_THRESHOLD)) {
+                    filters.add(GATKVCFConstants.STRAND_ARTIFACT_FILTER_NAME);
+                }
+            }
+        }
+    }
+
+    private static void applyEventDistanceFilters(final VariantContext vc, final Collection<String> filters) {
+        final Integer eventCount = vc.getAttributeAsInt(GATKVCFConstants.EVENT_COUNT_IN_HAPLOTYPE_KEY, -1);
+        if (eventCount >= 3) {
+            filters.add(GATKVCFConstants.HOMOLOGOUS_MAPPING_EVENT_FILTER_NAME);
+        }
+    }
+
+    //TODO: building a list via repeated side effects is ugly
+    public static Set<String> calculateFilters(final M2ArgumentCollection MTAC, final VariantContext vc) {
+        final Set<String> filters = new HashSet<>();
+        applyEventDistanceFilters(vc, filters);
+        applyTriallelicFilter(vc, filters);
+        applyPanelOfNormalsFilter(MTAC, vc, filters);
+        applyGermlineVariantFilter(MTAC, vc, filters);
+        applyClusteredReadPositionFilter(MTAC, vc, filters);
+        applyStrandBiasFilter(MTAC, vc, filters);
+        applySTRFilter(vc, filters);
+
+        return filters;
+    }
+
+
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/PerAlleleCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/PerAlleleCollection.java
@@ -110,4 +110,10 @@ public class PerAlleleCollection<X> {
     public Set<Allele> getAltAlleles(){
         return altAlleleValueMap.keySet();
     }
+
+    public Allele getRefAllele() {
+        Utils.validateArg(refAllele.isPresent(), "no ref allele");
+        return refAllele.get();
+    }
+
 }


### PR DESCRIPTION
* Closes issues #733, #735, and #807.
* Gets rid of a lot of arbitrary filters that have probably become obsolete
* moves filtering into a second pass
* deals with a lot of little TODOs
* emits all somatic alleles
* annotates the output vcf more than before