### PR TITLE
Remove -stand_emit_conf argument

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -112,7 +112,6 @@ import java.util.List;
  *     -I sample1.bam [-I sample2.bam ...] \
  *     [--dbsnp dbSNP.vcf] \
  *     [-stand_call_conf 30] \
- *     [-stand_emit_conf 10] \
  *     [-L targets.interval_list] \
  *     -o output.raw.snps.indels.vcf
  * </pre>
@@ -125,7 +124,6 @@ import java.util.List;
  *     -I sample1.bam \
  *     [--dbsnp dbSNP.vcf] \
  *     -stand_call_conf 20 \
- *     -stand_emit_conf 20 \
  *     -o output.raw.snps.indels.vcf
  * </pre>
  *

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
@@ -43,7 +43,7 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
                 {"combined_genotype_gvcf_exception.nocall.vcf", "combined_genotype_gvcf_exception.output.vcf", NO_EXTRA_ARGS},  //same test as above but with ./.
                 {basePairGVCF, "ndaTest.expected.vcf", Collections.singletonList("-nda")},  //annotating with the number of alleles discovered option
                 {basePairGVCF, "maxAltAllelesTest.expected.vcf", Arrays.asList("--maxAltAlleles", "1")}, //restricting the max number of alt alleles
-                {basePairGVCF, "standardConfTest.expected.vcf", Arrays.asList("-stand_call_conf", "300", "-stand_emit_conf", "100")}, //changing call and emission confidence
+                {basePairGVCF, "standardConfTest.expected.vcf", Arrays.asList("-stand_call_conf", "300")}, //changing call confidence
                 {"spanningDel.combined.g.vcf", "spanningDel.combined.g.vcf.expected.vcf", NO_EXTRA_ARGS},
                 {"spanningDel.delOnly.g.vcf", "spanningDel.delOnly.g.vcf.expected.vcf", NO_EXTRA_ARGS},
                 {"CEUTrio.20.21.gatk3.4.g.vcf", "CEUTrio.20.21.expected.vcf", Arrays.asList("--dbsnp", "src/test/resources/large/dbsnp_138.b37.20.21.vcf")},


### PR DESCRIPTION
Implements https://github.com/broadinstitute/gatk-protected/issues/728.
The `-stand_emit_conf` argument will fail once https://github.com/broadinstitute/gatk/pull/2314 is merged.
