### PR TITLE
Rev gatk public to 4.alpha.2-110-ga71331d-20161129.223512-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ check.dependsOn installDist
 
 dependencies {
     compile files("${System.properties['java.home']}/../lib/tools.jar")
-    compile 'org.broadinstitute:gatk:4.alpha.2-95-g64661b5-20161114.160836-1'
+    compile 'org.broadinstitute:gatk:4.alpha.2-110-ga71331d-20161129.223512-1'
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
 
     testCompile 'org.testng:testng:6.8.8'

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngine.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.SAMUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.QualityUtils;
@@ -138,7 +139,13 @@ public final class PairHMMLikelihoodCalculationEngine implements ReadLikelihoodC
         this.constantGCP = constantGCP;
         this.log10globalReadMismappingRate = log10globalReadMismappingRate;
         this.pcrErrorModel = pcrErrorModel;
-        pairHMM = hmmType.makeNewHMM();
+
+        // TODO: remove me once we're ready to expose the new PairHMM args:
+        final PairHMMNativeArguments pairHMMArgs = new PairHMMNativeArguments();
+        pairHMMArgs.maxNumberOfThreads = 1;
+        pairHMMArgs.useDoublePrecision = false;
+
+        pairHMM = hmmType.makeNewHMM(pairHMMArgs);
 
         initializePCRErrorModel();
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -63,6 +63,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
+                "-G", "StandardHCAnnotation",
                 "-G", "AS_StandardAnnotation",
                 "-pairHMM", "AVX_LOGLESS_CACHING"
         };
@@ -126,6 +127,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
+                "-G", "StandardHCAnnotation",
                 "-G", "AS_StandardAnnotation",
                 "-pairHMM", "AVX_LOGLESS_CACHING"
         };
@@ -177,6 +179,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
+                "-G", "StandardHCAnnotation",
                 "-G", "AS_StandardAnnotation",
                 "-ERC", "GVCF",
                 "-pairHMM", "AVX_LOGLESS_CACHING"
@@ -238,6 +241,7 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
+                "-G", "StandardHCAnnotation",
                 "-G", "AS_StandardAnnotation",
                 "-ERC", "GVCF",
                 "-pairHMM", "AVX_LOGLESS_CACHING"


### PR DESCRIPTION
-Fix failing HaplotypeCallerIntegrationTest by adjusting command lines
 to account for the change in public in commit:
 50cb7f70a28e1b7f8821ecfd2d2665aefaaae54d "Change list argument behavior to replace"

-Add a temporary shim in PairHMMLikelihoodCalculationEngine to allow
 us to compile pending the merge of https://github.com/broadinstitute/gatk-protected/pull/813