### PR TITLE
New tool that counts false positives in a vcf to be used for mutect2 NA12878 normal-normal validation

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CountFalsePositives.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CountFalsePositives.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.mutect;
 
 import htsjdk.variant.variantcontext.VariantContext;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
@@ -9,14 +10,16 @@ import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureDataSource;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.tsv.DataLine;
+import org.broadinstitute.hellbender.utils.tsv.TableColumnCollection;
+import org.broadinstitute.hellbender.utils.tsv.TableWriter;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.stream.Stream;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 
@@ -36,31 +39,28 @@ public class CountFalsePositives extends CommandLineProgram {
     @Argument(doc = "output file", fullName= "output", shortName = "O", optional = false)
     protected File output;
 
+
+    // TODO: eventually use tumor and normal sample names instead of the file name. To do so we must extract them from the vcf, which I don't know how.
     @Override
     public Object doWork() {
         Utils.regularReadableUserFile(vcfList);
-        String header = String.format("%s\t%s\t%s\n", "sample", "fps", "snp-or-indel");
-        StringBuilder sb = new StringBuilder(header);
-
-        try (
-                Stream<String> vcfFiles = Files.lines(Paths.get(vcfList.toString()));
-                PrintWriter outputWriter = new PrintWriter(new FileWriter(output))
-        ) {
-            sb = vcfFiles.reduce(sb,
-                    (acc, f) -> acc.append(countFalsePositivesAndBuildString(new File(f))),
-                    StringBuilder::append);
-            outputWriter.print(sb.toString());
+        try ( FalsePositiveTableWriter writer = new FalsePositiveTableWriter(output) ) {
+            List<String> vcfFilePaths = Files.readAllLines(Paths.get(vcfList.toString()));
+            List<File> vcfFiles = vcfFilePaths.stream().map(File::new).collect(Collectors.toList());
+            writer.writeAllRecords(vcfFiles);
         } catch (IOException e){
-            // TODO: catching the exception here and Utils.regularReadableUserFile() are redundant
             throw new UserException(String.format("Encountered an IO exception while reading (or reading a file in) %s or %s", vcfList.toString(), output));
         }
 
         return "SUCCESS";
     }
 
-    private static String countFalsePositivesAndBuildString(File m2vcf) {
-        final String sampleName = FilenameUtils.removeExtension(m2vcf.getName());
-
+    /***
+     *
+     * @param m2vcf a mutect2 vcf file
+     * @return a pair of SNP (left) and INDEL (right) false positives
+     */
+    private static Pair<Long, Long> countFalsePositives(File m2vcf) {
         final long snpFalsePositives = StreamSupport.stream(new FeatureDataSource<VariantContext>(m2vcf).spliterator(), false)
                 .filter(vc -> vc.getFilters().isEmpty())
                 .filter(vc -> vc.isSNP())
@@ -69,10 +69,24 @@ public class CountFalsePositives extends CommandLineProgram {
                 .filter(vc -> vc.getFilters().isEmpty())
                 .filter(vc -> !vc.isSNP())
                 .count();
+        return Pair.of(snpFalsePositives, indelFalsePositives);
+    }
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(String.format("%s\t%d\t%s\n", sampleName, snpFalsePositives, "snp"));
-        sb.append(String.format("%s\t%d\t%s\n", sampleName, indelFalsePositives, "indel"));
-        return sb.toString();
+    private class FalsePositiveTableWriter extends TableWriter<File> {
+        private FalsePositiveTableWriter(final File output) throws IOException {
+            super(output, new TableColumnCollection("filename", "snp", "indel"));
+        }
+
+        @Override
+        protected void composeLine(final File vcf, final DataLine dataLine) {
+            Utils.nonNull(vcf, "the vcf file cannot be null");
+            Utils.nonNull(dataLine, "dataLine cannot be null");
+
+            Pair<Long, Long> falsePositives = countFalsePositives(vcf);
+
+            dataLine.set("filename", FilenameUtils.removeExtension(vcf.getName()))
+                    .set("snp", falsePositives.getLeft())
+                    .set("indel",falsePositives.getRight());
+        }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CountFalsePositives.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/CountFalsePositives.java
@@ -1,0 +1,78 @@
+package org.broadinstitute.hellbender.tools.walkers.mutect;
+
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.commons.io.FilenameUtils;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
+import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+
+@CommandLineProgramProperties(
+        summary = "Count PASS (false positive) variants in a vcf file for Mutect2 NA12878 normal-normal evaluation",
+        oneLineSummary = "Count PASS variants",
+        programGroup = VariantProgramGroup.class
+
+)
+/**
+ * Created by tsato on 12/28/16.
+ */
+public class CountFalsePositives extends CommandLineProgram {
+    @Argument(doc = "a line-delimited list of mutect2 vcf files", fullName= "", shortName = "V", optional = false)
+    protected File vcfList;
+
+    @Argument(doc = "output file", fullName= "output", shortName = "O", optional = false)
+    protected File output;
+
+    @Override
+    public Object doWork() {
+        Utils.regularReadableUserFile(vcfList);
+        String header = String.format("%s\t%s\t%s\n", "sample", "fps", "snp-or-indel");
+        StringBuilder sb = new StringBuilder(header);
+
+        try (
+                Stream<String> vcfFiles = Files.lines(Paths.get(vcfList.toString()));
+                PrintWriter outputWriter = new PrintWriter(new FileWriter(output))
+        ) {
+            sb = vcfFiles.reduce(sb,
+                    (acc, f) -> acc.append(countFalsePositivesAndBuildString(new File(f))),
+                    StringBuilder::append);
+            outputWriter.print(sb.toString());
+        } catch (IOException e){
+            // TODO: catching the exception here and Utils.regularReadableUserFile() are redundant
+            throw new UserException(String.format("Encountered an IO exception while reading (or reading a file in) %s or %s", vcfList.toString(), output));
+        }
+
+        return "SUCCESS";
+    }
+
+    private static String countFalsePositivesAndBuildString(File m2vcf) {
+        final String sampleName = FilenameUtils.removeExtension(m2vcf.getName());
+
+        final long snpFalsePositives = StreamSupport.stream(new FeatureDataSource<VariantContext>(m2vcf).spliterator(), false)
+                .filter(vc -> vc.getFilters().isEmpty())
+                .filter(vc -> vc.isSNP())
+                .count();
+        final long indelFalsePositives = StreamSupport.stream(new FeatureDataSource<VariantContext>(m2vcf).spliterator(), false)
+                .filter(vc -> vc.getFilters().isEmpty())
+                .filter(vc -> !vc.isSNP())
+                .count();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("%s\t%d\t%s\n", sampleName, snpFalsePositives, "snp"));
+        sb.append(String.format("%s\t%d\t%s\n", sampleName, indelFalsePositives, "indel"));
+        return sb.toString();
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/CountFalsePositivesTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/CountFalsePositivesTest.java
@@ -1,0 +1,43 @@
+package org.broadinstitute.hellbender.tools.walkers.mutect;
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.testng.Assert.*;
+
+/**
+ * Created by tsato on 12/28/16.
+ */
+public class CountFalsePositivesTest extends CommandLineProgramTest {
+
+    /***
+     * Make sure that the tool runs to completion and prints out the correct number of lines
+     */
+    @Test
+    public void testEvaluateMutect2() throws Exception {
+        final String dreamDir =  publicTestDir + "org/broadinstitute/hellbender/tools/mutect/dream/vcfs/";
+        List<String> vcfList = Arrays.asList(dreamDir + "sample_1.vcf", dreamDir + "sample_2.vcf", dreamDir + "sample_3.vcf", dreamDir + "sample_4.vcf");
+        final File vcfListFile = createTempFile("vcfList", ".txt");
+        final File output = createTempFile("output", ".txt");
+        Path file = Paths.get(vcfListFile.getAbsolutePath());
+        Files.write(file, vcfList, Charset.forName("UTF-8"));
+        final String[] args = {
+                "-V", vcfListFile.toString(),
+                "-O", output.toString()
+        };
+        runCommandLine(args);
+        Stream<String> outputLines = Files.lines(Paths.get(output.getAbsolutePath()));
+        Assert.assertEquals(outputLines.count(), 9L);
+
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/CountFalsePositivesTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/mutect/CountFalsePositivesTest.java
@@ -36,7 +36,7 @@ public class CountFalsePositivesTest extends CommandLineProgramTest {
         };
         runCommandLine(args);
         Stream<String> outputLines = Files.lines(Paths.get(output.getAbsolutePath()));
-        Assert.assertEquals(outputLines.count(), 9L);
+        Assert.assertEquals(outputLines.count(), 5L);
 
     }
 


### PR DESCRIPTION
@davidbenjamin I wrote a simple tool for mutect2 NA12878 validation. It takes a list of vcfs, counts the number of SNP and INDEL variants (i.e. PASS variants) in each file, and prints the counts in a tsv format. Please take a look!