### PR TITLE
Remove tools.jar dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,6 @@ build.dependsOn installDist
 check.dependsOn installDist
 
 dependencies {
-    compile files("${System.properties['java.home']}/../lib/tools.jar")
     compile 'org.broadinstitute:gatk:4.alpha.2-130-g6a23efd-20170103.175407-1'
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
 


### PR DESCRIPTION
We really shouldn't have a compile dependency on tools.jar; doing so propagates it through the uber.jar. Building and testing seem to pass without it. If there is another gradle target (or some runtime code) that requires it, we can try to address that. Otherwise the dependency should be removed.