### PR TITLE
add runtime clauses and fix glob

### DIFF
--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -46,6 +46,12 @@ task M2 {
     -O ${tumor_sample_name}-vs-${normal_sample_name}.vcf
   }
 
+  runtime {
+    docker: "$__docker__"
+    memory: "$__large_memory__"
+    disks: "local-disk " + $__large_disk__ + " HDD"
+  }
+
   output {
     File output_vcf = "${tumor_sample_name}-vs-${normal_sample_name}.vcf"
   }
@@ -60,6 +66,12 @@ task MergeVCFs {
   # WARNING 2015-10-28 15:01:48 GatherVcfs  Index creation not currently supported when gathering block compressed VCFs.
   command {
     java -Xmx2g -jar ${gatk4_jar} MergeVcfs -I ${sep=' -I ' input_vcfs} -O ${output_vcf_name}.vcf
+  }
+
+  runtime {
+    docker: "$__docker__"
+    memory: "$__medium_memory__"
+    disks: "local-disk " + $__medium_disk__ + " HDD"
   }
 
   output {
@@ -77,6 +89,12 @@ task Filter {
   	java -Xmx4g -jar ${gatk4_jar} FilterMutectCalls -V ${unfiltered_calls} -O ${output_vcf_name}.vcf
   }
 
+  runtime {
+    docker: "$__docker__"
+    memory: "$__large_memory__"
+    disks: "local-disk " + $__large_disk__ + " HDD"
+  }
+
   output {
     File output_vcf = "${output_vcf_name}.vcf"
   }
@@ -91,6 +109,12 @@ task SplitIntervals {
   command {
     mkdir intervalFileDir
     java -jar ${gatk4_jar} IntervalListTools -I ${intervals} -O intervalFileDir -SCATTER_COUNT ${scatterCount}
+  }
+
+  runtime {
+    docker: "$__docker__"
+    memory: "$__medium_memory__"
+    disks: "local-disk " + $__small_disk__ + " HDD"
   }
 
   output {

--- a/scripts/mutect2_wdl/mutect2.wdl
+++ b/scripts/mutect2_wdl/mutect2.wdl
@@ -48,8 +48,8 @@ task M2 {
 
   runtime {
     docker: "$__docker__"
-    memory: "$__large_memory__"
-    disks: "local-disk " + $__large_disk__ + " HDD"
+    memory: "5 GB"
+    disks: "local-disk " + 500 + " HDD"
   }
 
   output {
@@ -70,8 +70,8 @@ task MergeVCFs {
 
   runtime {
     docker: "$__docker__"
-    memory: "$__medium_memory__"
-    disks: "local-disk " + $__medium_disk__ + " HDD"
+    memory: "3 GB"
+    disks: "local-disk " + 300 + " HDD"
   }
 
   output {
@@ -91,8 +91,8 @@ task Filter {
 
   runtime {
     docker: "$__docker__"
-    memory: "$__large_memory__"
-    disks: "local-disk " + $__large_disk__ + " HDD"
+    memory: "5 GB"
+    disks: "local-disk " + 500 + " HDD"
   }
 
   output {
@@ -113,8 +113,8 @@ task SplitIntervals {
 
   runtime {
     docker: "$__docker__"
-    memory: "$__medium_memory__"
-    disks: "local-disk " + $__small_disk__ + " HDD"
+    memory: "3 GB"
+    disks: "local-disk " + 100 + " HDD"
   }
 
   output {


### PR DESCRIPTION
@davidbenjamin This change adds runtime clauses to `mutect2.wdl`. Now this single wdl can run in the cloud and on SGE. Users must supply the runtime parameters (e.g. `$__docker__`) themselves. I have a script that populates those parameters for broad internal uses; this script will live in the palantir repo under `Analysis/mutect2-evaluation`. Cromwell ignores runtime clauses when irrelevant (e.g. when we submit the jobs to SGE).

I also modified the code surrounding `glob` so it works on cromwell v24; in v24 and later, cromwell `glob` looks for files in the current working directory only.