### PR TITLE
Add "gradle localJar" as replacement for "gradle shadowJar", and adjust jar naming to be consistent with public

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ GATK4 development of the license-protected part of the toolkit
 
 This README is aimed at developers.  For user information, please see the [GATK 4 forum](http://gatkforums.broadinstitute.org/gatk/categories/gatk-4-alpha)
 
+Read GATK 4 README
+------------------------
+
+**Please refer to the [GATK 4 public repo README](https://github.com/broadinstitute/hellbender/blob/master/README.md) for general guidelines and how to setup your development environment.**
+
 Requirements
 ------------
 * R 3.1.3 see additional requirements below: [R package requirements](#r-required-packages)
@@ -19,22 +24,108 @@ download and use an appropriate gradle version automatically.
 
 * (Developers) git lfs 1.1.0 (or greater) is needed for testing GATK-Protected builds.  It is needed to download large files for the complete test suite. Run ``git lfs install`` after downloading, followed by ``git lfs pull`` to download the large files. The download is ~500 MB.
 
-Read GATK 4 README
-------------------------
-
-Please refer to the GATK 4 public repo readme file for general guidelines and how to set-up your development environment:
-
-https://github.com/broadinstitute/hellbender/blob/master/README.md
-
-
 #### R Required Packages
 R packages can be installed using the install_R_packages.R script inside the scripts directory.
 
-### Create the jar file
+##Building GATK4
 
-`` ./gradlew shadowJar ``
+* To do a fast build that lets you run GATK tools from within a git clone locally (but not on a cluster), run:
+        
+        ./gradlew installDist
+        
+* To do a slower build that lets you run GATK tools from within a git clone both locally and on a cluster, run:
 
-A jar file will appear in ``build/libs``.
+        ./gradlew installAll
+     
+* To build a fully-packaged GATK jar that can be distributed and includes all dependencies needed for running tools locally, run:
+
+        ./gradlew localJar
+        
+    * The resulting jar will be in `build/libs` with a name like `gatk-protected-package-VERSION-local.jar`
+    
+* To build a fully-packaged GATK jar that can be distributed and includes all dependencies needed for running spark tools on a cluster, run:
+
+        ./gradlew sparkJar
+        
+    * The resulting jar will be in `build/libs` with a name like `gatk-protected-package-VERSION-spark.jar`
+    * This jar will not include Spark and Hadoop libraries, in order to allow the versions of Spark and Hadoop installed on your cluster to be used.
+
+* To remove previous builds, run: 
+
+        ./gradlew clean
+        
+##Running GATK4
+
+* The standard way to run GATK4 tools is via the **`gatk-launch`** wrapper script located in the root directory of a clone of this repository.
+    * Requires Python 2.6 or greater.
+    * You need to have built the GATK as described in the "Building GATK4" section above before running this script.
+    * There are three ways `gatk-launch` can be run:
+        * from the root of your git clone after building
+        * or, put the `gatk-launch` script within the same directory as fully-packaged GATK jars produced by `./gradlew localJar` and `./gradlew sparkJar`
+        * or, the environment variables `GATK_LOCAL_JAR` and `GATK_SPARK_JAR` can be defined, and contain the paths to the fully-packaged GATK jars produced by `./gradlew localJar` and `./gradlew sparkJar` 
+    * Can run non-Spark tools as well as Spark tools, and can run Spark tools locally, on a Spark cluster, or on Google Cloud Dataproc.
+
+* For help on using `gatk-launch` itself, run **`./gatk-launch --help`**
+
+* To print a list of available tools, run **`./gatk-launch --list`**.
+
+* To print help for a particular tool, run **`./gatk-launch ToolName --help`**.
+
+* To run a non-Spark tool, or to run a Spark tool locally, the syntax is:
+    ```
+    ./gatk-launch ToolName toolArguments
+    ```
+    *Examples:*
+    ```
+    ./gatk-launch PrintReads -I input.bam -O output.bam
+
+    ./gatk-launch PrintReadsSpark -I input.bam -O output.bam
+    ```
+
+* To run a Spark tool on a Spark cluster, the syntax is:
+    ```
+    ./gatk-launch ToolName toolArguments -- --sparkRunner SPARK --sparkMaster <master_url> additionalSparkArguments
+    ```
+    *Example:*
+    ```
+    ./gatk-launch PrintReadsSpark -I hdfs://path/to/input.bam -O hdfs://path/to/output.bam \
+        -- \
+        --sparkRunner SPARK --sparkMaster <master_url> \
+        --num-executors 5 --executor-cores 2 --executor-memory 4g \
+        --conf spark.yarn.executor.memoryOverhead=600
+    ```
+
+* To run a Spark tool on Google Cloud Dataproc, the syntax is:
+    ```
+    ./gatk-launch ToolName toolArguments -- --sparkRunner GCS --cluster myGCSCluster additionalSparkArguments
+    ```
+    *Example:*
+    ```
+    ./gatk-launch PrintReadsSpark \
+          -I gs://my-gcs-bucket/path/to/input.bam \
+          -O gs://my-gcs-bucket/path/to/output.bam \
+          -- \
+          --sparkRunner GCS --cluster myGCSCluster \
+          --num-executors 5 --executor-cores 2 --executor-memory 4g \
+          --conf spark.yarn.executor.memoryOverhead=600
+    ```
+    
+* **See the [GATK4 public README](https://github.com/broadinstitute/hellbender/blob/master/README.md) for full instructions on using `gatk-launch` to run tools on a Spark/Dataproc cluster.**
+
+##Testing GATK4
+
+* To run the tests, run **`./gradlew test`**.
+    * Test report is in `build/reports/tests/test/index.html`. 
+    * Note that `git lfs` must be installed and set up as described in the "Requirements" section above
+      in order for all tests to pass.
+
+* To run a subset of tests, use gradle's test filtering (see [gradle doc](https://docs.gradle.org/current/userguide/java_plugin.html)), e.g.,
+    * `./gradlew test -Dtest.single=SomeSpecificTestClass`
+    * `./gradlew test --tests *SomeSpecificTestClass`
+    * `./gradlew test --tests all.in.specific.package*`
+    * `./gradlew test --tests *SomeTest.someSpecificTestMethod`
+
+* **See the [GATK4 public README](https://github.com/broadinstitute/hellbender/blob/master/README.md) for further information on running tests.**
 
 The CNV case and PoN workflows (description and examples)
 ---------------------------------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -238,7 +238,7 @@ task wrapper(type: Wrapper) {
 
 tasks.withType(ShadowJar) {
     from(project.sourceSets.main.output)
-    baseName = project.name + '-all'
+    baseName = project.name + '-package'
     mergeServiceFiles()
 
     // Suggested by the akka devs to make sure that we do not get the spark configuration error.
@@ -254,13 +254,17 @@ tasks.withType(ShadowJar) {
 }
 
 shadowJar {
-    classifier = 'spark_standalone'
+    classifier = 'local'
     doLast {
         // Create a symlink to the newly created jar.  The name will be hellbender-protected.jar and
         //  it will be at the same level as the newly created jar.  (overwriting symlink, if it exists)
         // Please note that this will cause failures in Windows, which does not support symlinks.
         createAllSymlinks(destinationDir.toString(), archivePath, "")
     }
+}
+
+task localJar {
+    dependsOn shadowJar 
 }
 
 task sparkJar(type: ShadowJar) {


### PR DESCRIPTION
-Add a new "gradle localJar" target that just runs shadowJar

-The localJar/shadowJar name now ends in a "local.jar" suffix, to
 better distinguish it from the spark jar. This is consistent with
 gatk public, and (critically) with the names that the gatk-launch
 script now expects. This fixes a failure in gatk-launch.

-Kept "gradle shadowJar" around for backwards compatibility, but removed
 mention from README

-Include the word "package" in the name for jars that contain all dependencies
 (again, for consistency with gatk public)

-Updated the README with basic information on building and running
 GATK4 copied from the public README, with links back to the public
 README for further details.

Resolves #873