### PR TITLE
Simplified M2 isActive, increasing speed and sensitivity. Closes #801.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/AbstractConcordanceWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/AbstractConcordanceWalker.java
@@ -95,6 +95,7 @@ public abstract class AbstractConcordanceWalker extends GATKTool {
     @Override
     protected final void onStartup() {
         super.onStartup();
+
         initializeTruthVariantsIfNecessary();
         evalVariants = new FeatureDataSource<>(new FeatureInput<>(evalVariantsFile, "eval"), CACHE_LOOKAHEAD, VariantContext.class);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -45,10 +45,22 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public FeatureInput<VariantContext> normalPanelFeatureInput;
 
     /**
-     * This is the LOD threshold that a variant must pass in the tumor to be emitted to the VCF. Note that the variant may pass this threshold yet still be annotated as FILTERed based on other criteria.
+     * Minimum number of variant reads in pileup to be considered an active region.
      */
-    @Argument(fullName = "initial_tumor_lod", optional = true, doc = "Initial LOD threshold for calling tumor variant")
-    public double INITIAL_TUMOR_LOD_THRESHOLD = 4.0;
+    @Argument(fullName = "min_variants_in_pileup", optional = true, doc = "Minimum number of reads in pileup to be considered active region.")
+    public int minVariantsInPileup = 2;
+
+    /**
+     * How many standard deviations above the expected number of variant reads due to error we require for a tumor pielup to be considered active
+     */
+    @Argument(fullName = "tumorStandardDeviationsThreshold", optional = true, doc = "How many standard deviations above the expected number of variant reads due to error we require for a tumor pielup to be considered active.")
+    public int tumorStandardDeviationsThreshold = 2;
+
+    /**
+     * Minimum allele fraction of variant reads in normal for a pileup to be considered inactive
+     */
+    @Argument(fullName = "minNormalVariantFraction", optional = true, doc = "Minimum number of reads in pileup to be considered active region.")
+    public double minNormalVariantFraction = 0.1;
 
     /**
      * Only variants with tumor LODs exceeding this threshold can pass filtering.


### PR DESCRIPTION
At least on our DREAM challenge integration tests, it turns out that `isActive()` in `Mutect2Engine` was: 1) too permissive of sites including, *some with zero evidence of variation whatsoever*; 2) prone to throwing away good variants; 3) sufficiently complex that the act of determining activity itself, as opposed to the consequence of genotyping too many inactive sites, took a significant amount of time.

This simplification improved sensitivity on DREAM 3 and DREAM 4by a bit while running about three times as fast.  Based on these results, as well as manual review in IGV of several hundred sites, I feel pretty confident in this change.  I am currently running the CRSP sensitivity validation with the old code, so we will have a point of reference.