### PR TITLE
Rev GATK public dependency to 4.alpha.2-188-g7332d10-20170321.172613-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ build.dependsOn installDist
 check.dependsOn installDist
 
 dependencies {
-    compile 'org.broadinstitute:gatk:4.alpha.2-184-g88c181d-20170320.193607-1'
+    compile 'org.broadinstitute:gatk:4.alpha.2-188-g7332d10-20170321.172613-1'
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
 
     testCompile 'org.testng:testng:6.8.8'


### PR DESCRIPTION
This includes a fix to gatk-launch