### PR TITLE
Filter reads before assembly in Mutect. Closes #723.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -85,12 +85,6 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     public float STRAND_ARTIFACT_LOD_THRESHOLD = 2.0f;
 
     /**
-     * Reads with mapping qualities below this threshold will be filtered out
-     */
-    @Argument(fullName = "min_mapping_quality_score", shortName = "mmq", doc = "Minimum read mapping quality required to consider a read for analysis", optional = true)
-    public int MIN_MAPPING_QUALITY_SCORE = 20;
-
-    /**
      * Which annotations to add to the output VCF file. See the VariantAnnotator -list argument to view available annotations.
      */
     @Advanced

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
-import org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypingEngine;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.afcalc.AFCalculator;
 import org.broadinstitute.hellbender.tools.walkers.genotyper.afcalc.AFCalculatorProvider;
 import org.broadinstitute.hellbender.tools.walkers.haplotypecaller.*;
@@ -83,14 +82,12 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
      *
      * The list of samples we're working with is obtained from the readLikelihoods
      * @param readLikelihoods                       Map from reads->(haplotypes,likelihoods)
-     * @param perSampleFilteredReadList              Map from sample to reads that were filtered after assembly and before calculating per-read likelihoods.
      * @param activeRegionWindow                     Active window
      *
      * @return                                       A CalledHaplotypes object containing a list of VC's with genotyped events and called haplotypes
      */
     public CalledHaplotypes callMutations(
             final ReadLikelihoods<Haplotype> readLikelihoods,
-            final Map<String, List<GATKRead>> perSampleFilteredReadList,
             final AssemblyResultSet assemblyResultSet,
             final ReferenceContext referenceContext,
             final SimpleInterval activeRegionWindow,
@@ -174,8 +171,7 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
             }
 
             final VariantContext call = addGenotypes(hasNormal, allSomaticAlleles, readAlleleLikelihoods, tumorAlleleFractions, callVcb);
-            // how should we be making use of _perSampleFilteredReadList_?
-            readAlleleLikelihoods = prepareReadAlleleLikelihoodsForAnnotation(readLikelihoods, perSampleFilteredReadList,
+            readAlleleLikelihoods = prepareReadAlleleLikelihoodsForAnnotation(readLikelihoods, Collections.emptyMap(),
                     false, alleleMapper, readAlleleLikelihoods, call);
 
             final VariantContext annotatedCall =  annotationEngine.annotateContext(call, featureContext, referenceContext, readAlleleLikelihoods, a -> true);


### PR DESCRIPTION
@takutosato You saw the improvement in sensitivity on DREAM.  HapMap showed the same.  Normal-normal false positives were about the same.  Most of the changes are straightforward.  The stuff about `perSampledFilteredReadList` is that we used to keep track of filtered reads in order to annotate based on those.  1) I don't think that makes much sense.  2) We can't do that any longer because those reads are filtered before `Mutect2Engine` see them.

@LeeTL1220 You might be interested in knowing that this improved sensitivity in all the DREAM challenges by about 3%.

@droazen @yfarjoun @ldgauthier HaplotypeCaller has the same comment as Mutect asking whether this change is worthwhile.  Might be worth investigating making the change there, too.