### PR TITLE
Move to a snapshot of gatk-public based on 4.alpha.2-188-g7332d10 with TandemRepeat fix applied

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ build.dependsOn installDist
 check.dependsOn installDist
 
 dependencies {
-    compile 'org.broadinstitute:gatk:4.alpha.2-188-g7332d10-20170321.172613-1'
+    compile 'org.broadinstitute:gatk:4.alpha.2-189-g056f196-20170404.231309-1'
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
 
     testCompile 'org.testng:testng:6.8.8'


### PR DESCRIPTION
This moves us to a snapshot of gatk-public that takes the version gatk-protected
currently depends on (4.alpha.2-188-g7332d10) and applies JUST @davidbenjamin 's fix
to the TandemRepeat annotation to it.

This is necessary to unblock @davidbenjamin 's work, because the HaplotypeCaller
tests are failing if we update protected to the latest public HEAD, and although we've
fixed some of the issues there are still some unexplained failures in the concordance tests.