### PR TITLE
Rev GATK dependency to 4.alpha.2-214-g09b380e-20170405.195304-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ build.dependsOn installDist
 check.dependsOn installDist
 
 dependencies {
-    compile 'org.broadinstitute:gatk:4.alpha.2-189-g056f196-20170404.231309-1'
+    compile 'org.broadinstitute:gatk:4.alpha.2-214-g09b380e-20170405.195304-1'
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
 
     testCompile 'org.testng:testng:6.8.8'

--- a/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSparkIntegrationTest.java
@@ -50,18 +50,19 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
                 "-R", b37_2bit_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
 
         final double concordance = HaplotypeCallerIntegrationTest.calculateConcordance(output, gatk3Output);
-        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in VCF mode is < 99%");
+        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in VCF mode is < 99% (" +  concordance + ")");
     }
 
     /**
      * Test that in VCF mode we're >= 99% concordant with GATK3.5 results
-     * THIS TEST explodes with an exeption because Allele-Specific annotations are not supported in vcf mode yet.
+     * THIS TEST explodes with an exception because Allele-Specific annotations are not supported in vcf mode yet.
      * It's included to parallel the matching (also exploding) test for the non-spark HaplotypeCaller
      * {@link org.broadinstitute.hellbender.tools.walkers.haplotypecaller.HaplotypeCallerIntegrationTest#testVCFModeIsConcordantWithGATK3_5ResultsAlleleSpecificAnnotations()}
      */
@@ -86,13 +87,14 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
                 "-O", output.getAbsolutePath(),
                 "-G", "StandardAnnotation",
                 "-G", "AS_StandardAnnotation",
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
 
         final double concordance = HaplotypeCallerIntegrationTest.calculateConcordance(output, gatk3Output);
-        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in AS VCF mode is < 99%");
+        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in AS VCF mode is < 99% (" +  concordance + ")");
     }
 
     /*
@@ -117,13 +119,14 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-ERC", "GVCF",
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
 
         final double concordance = HaplotypeCallerIntegrationTest.calculateConcordance(output, gatk3Output);
-        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in GVCF mode is < 99%");
+        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in GVCF mode is < 99% (" +  concordance + ")");
     }
 
 
@@ -148,13 +151,14 @@ public class HaplotypeCallerSparkIntegrationTest extends CommandLineProgramTest 
                 "-G", "StandardAnnotation",
                 "-G", "AS_StandardAnnotation",
                 "-ERC", "GVCF",
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
 
         final double concordance = HaplotypeCallerIntegrationTest.calculateConcordance(output, gatk3Output);
-        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in AS GVCF mode is < 99%");
+        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in AS GVCF mode is < 99% (" +  concordance + ")");
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFsIntegrationTest.java
@@ -23,7 +23,9 @@ import java.util.function.BiConsumer;
 
 public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
 
-    private static final List<String> NO_EXTRA_ARGS = Collections.emptyList();
+    //This value was originally 30 but was changed to 10.  We're setting most tests to use 30 to temporarily avoid having
+    //to update the expected outputs
+    private static final List<String> STAND_CALL_CONF_30 = Arrays.asList("-stand_call_conf", "30");
 
     private static <T> void assertForEachElementInLists(final List<T> actual, final List<T> expected, final BiConsumer<T, T> assertion) {
         Assert.assertEquals(actual.size(), expected.size(), "different number of elements in lists");
@@ -36,17 +38,17 @@ public class GenotypeGVCFsIntegrationTest extends CommandLineProgramTest {
     public Object[][] gvcfsToGenotype() {
         String basePairGVCF = "gvcf.basepairResolution.gvcf";
         return new Object[][]{
-                {basePairGVCF, "gvcf.basepairResolution.output.vcf", NO_EXTRA_ARGS}, //base pair level gvcf
-                {"testUpdatePGT.gvcf", "testUpdatePGT.output.vcf", NO_EXTRA_ARGS},   //testUpdatePGTStrandAlleleCountsBySample
-                {"gvcfExample1.vcf", "gvcfExample1.vcf.expected.vcf", NO_EXTRA_ARGS}, //single sample vcf
-                {"combined_genotype_gvcf_exception.vcf", "combined_genotype_gvcf_exception.output.vcf", NO_EXTRA_ARGS}, //test that an input vcf with 0/0 already in GT field is overwritten
-                {"combined_genotype_gvcf_exception.nocall.vcf", "combined_genotype_gvcf_exception.output.vcf", NO_EXTRA_ARGS},  //same test as above but with ./.
-                {basePairGVCF, "ndaTest.expected.vcf", Collections.singletonList("-nda")},  //annotating with the number of alleles discovered option
-                {basePairGVCF, "maxAltAllelesTest.expected.vcf", Arrays.asList("--maxAltAlleles", "1")}, //restricting the max number of alt alleles
+                {basePairGVCF, "gvcf.basepairResolution.output.vcf", STAND_CALL_CONF_30}, //base pair level gvcf
+                {"testUpdatePGT.gvcf", "testUpdatePGT.output.vcf", STAND_CALL_CONF_30},   //testUpdatePGTStrandAlleleCountsBySample
+                {"gvcfExample1.vcf", "gvcfExample1.vcf.expected.vcf", STAND_CALL_CONF_30}, //single sample vcf
+                {"combined_genotype_gvcf_exception.vcf", "combined_genotype_gvcf_exception.output.vcf", STAND_CALL_CONF_30}, //test that an input vcf with 0/0 already in GT field is overwritten
+                {"combined_genotype_gvcf_exception.nocall.vcf", "combined_genotype_gvcf_exception.output.vcf", STAND_CALL_CONF_30},  //same test as above but with ./.
+                {basePairGVCF, "ndaTest.expected.vcf", Arrays.asList("-nda", "-stand_call_conf", "30")},  //annotating with the number of alleles discovered option
+                {basePairGVCF, "maxAltAllelesTest.expected.vcf", Arrays.asList("--maxAltAlleles", "1", "-stand_call_conf", "30")}, //restricting the max number of alt alleles
                 {basePairGVCF, "standardConfTest.expected.vcf", Arrays.asList("-stand_call_conf", "300")}, //changing call confidence
-                {"spanningDel.combined.g.vcf", "spanningDel.combined.g.vcf.expected.vcf", NO_EXTRA_ARGS},
-                {"spanningDel.delOnly.g.vcf", "spanningDel.delOnly.g.vcf.expected.vcf", NO_EXTRA_ARGS},
-                {"CEUTrio.20.21.gatk3.4.g.vcf", "CEUTrio.20.21.expected.vcf", Arrays.asList("--dbsnp", "src/test/resources/large/dbsnp_138.b37.20.21.vcf")},
+                {"spanningDel.combined.g.vcf", "spanningDel.combined.g.vcf.expected.vcf", STAND_CALL_CONF_30},
+                {"spanningDel.delOnly.g.vcf", "spanningDel.delOnly.g.vcf.expected.vcf", STAND_CALL_CONF_30},
+                {"CEUTrio.20.21.gatk3.4.g.vcf", "CEUTrio.20.21.expected.vcf", Arrays.asList("--dbsnp", "src/test/resources/large/dbsnp_138.b37.20.21.vcf", "-stand_call_conf", "30")},
                 //{basePairGVCF, "gvcf.basepairResolution.includeNonVariantSites.expected.vcf", Collections.singletonList("--includeNonVariantSites")
         };
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerIntegrationTest.java
@@ -35,7 +35,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-R", b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
@@ -65,7 +66,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-G", "StandardAnnotation",
                 "-G", "StandardHCAnnotation",
                 "-G", "AS_StandardAnnotation",
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
@@ -95,13 +97,14 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-R", b37_reference_20_21,
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
 
         final double concordance = calculateConcordance(output, gatk3Output);
-        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in VCF mode is < 99%");
+        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in VCF mode is < 99% (" +  concordance + ")");
     }
 
     /*
@@ -129,13 +132,14 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-G", "StandardAnnotation",
                 "-G", "StandardHCAnnotation",
                 "-G", "AS_StandardAnnotation",
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
 
         final double concordance = calculateConcordance(output, gatk3Output);
-        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in AS VCF mode is < 99%");
+        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in AS VCF mode is < 99% (" +  concordance + ")");
     }
 
     /*
@@ -154,7 +158,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-ERC", "GVCF",
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
@@ -182,7 +187,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-G", "StandardHCAnnotation",
                 "-G", "AS_StandardAnnotation",
                 "-ERC", "GVCF",
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
@@ -213,13 +219,14 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:10000000-10100000",
                 "-O", output.getAbsolutePath(),
                 "-ERC", "GVCF",
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
 
         final double concordance = calculateConcordance(output, gatk3Output);
-        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in GVCF mode is < 99%");
+        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in GVCF mode is < 99% (" +  concordance + ")");
     }
 
     @Test
@@ -244,13 +251,14 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-G", "StandardHCAnnotation",
                 "-G", "AS_StandardAnnotation",
                 "-ERC", "GVCF",
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
 
         final double concordance = calculateConcordance(output, gatk3Output);
-        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in AS GVCF mode is < 99%.");
+        Assert.assertTrue(concordance >= 0.99, "Concordance with GATK 3.5 in AS GVCF mode is < 99% (" +  concordance + ")");
     }
 
     @Test
@@ -275,7 +283,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", testInterval,
                 "-O", vcfOutput.getAbsolutePath(),
                 "-bamout", bamOutput.getAbsolutePath(),
-                "-pairHMM", "AVX_LOGLESS_CACHING"
+                "-pairHMM", "AVX_LOGLESS_CACHING",
+                "-stand_call_conf", "30.0"
         };
 
         runCommandLine(args);
@@ -304,7 +313,8 @@ public class HaplotypeCallerIntegrationTest extends CommandLineProgramTest {
                 "-L", "20:11363580-11363600",
                 "-O", output.getAbsolutePath(),
                 "-ploidy", "4",
-                "-maxGT", "15"
+                "-maxGT", "15",
+                "-stand_call_conf", "30.0"
         };
         runCommandLine(args);
 


### PR DESCRIPTION
* Includes a fix to GenotypingEngine in public necessary to get the
  HaplotypeCaller tests passing with the latest gatk-public

* Updated HaplotypeCallerIntegrationTest to use "-stand_call_conf 30.0"
  for now, so that we don't have to deal with the migration to a default
  stand_call_conf of 10.0 just yet.