### PR TITLE
Added support for new PairHMM interface in GATK for passing PairHMMNativeArguments...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ build.dependsOn installDist
 check.dependsOn installDist
 
 dependencies {
-    compile 'org.broadinstitute:gatk:4.alpha.2-221-g2ecdef4-20170410.183103-1'
+    compile 'org.broadinstitute:gatk:4.alpha.2-226-gfade3c6-20170420.222947-1'
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
 
     testCompile 'org.testng:testng:6.8.8'

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/AssemblyBasedCallerUtils.java
@@ -167,7 +167,7 @@ public class AssemblyBasedCallerUtils {
 
         switch ( likelihoodArgs.likelihoodEngineImplementation) {
             case PairHMM:
-                return new PairHMMLikelihoodCalculationEngine((byte) likelihoodArgs.gcpHMM, likelihoodArgs.pairHMM, log10GlobalReadMismappingRate, likelihoodArgs.pcrErrorModel, likelihoodArgs.BASE_QUALITY_SCORE_THRESHOLD);
+                return new PairHMMLikelihoodCalculationEngine((byte) likelihoodArgs.gcpHMM, likelihoodArgs.pairHMMNativeArgs.getPairHMMArgs(), likelihoodArgs.pairHMM, log10GlobalReadMismappingRate, likelihoodArgs.pcrErrorModel, likelihoodArgs.BASE_QUALITY_SCORE_THRESHOLD);
             case Random:
                 return new RandomLikelihoodCalculationEngine();
             default:

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/LikelihoodEngineArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/LikelihoodEngineArgumentCollection.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
 
 import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.Hidden;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.pairhmm.PairHMM;
@@ -65,5 +66,8 @@ public final class LikelihoodEngineArgumentCollection implements Serializable {
     @Advanced
     @Argument(fullName="phredScaledGlobalReadMismappingRate", shortName="globalMAPQ", doc="The global assumed mismapping rate for reads", optional = true)
     public int phredScaledGlobalReadMismappingRate = 45;
+
+    @ArgumentCollection
+    public PairHMMNativeArgumentCollection pairHMMNativeArgs = new PairHMMNativeArgumentCollection();
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngine.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.SAMUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.QualityUtils;
@@ -99,10 +100,11 @@ public final class PairHMMLikelihoodCalculationEngine implements ReadLikelihoodC
      * @param pcrErrorModel model to correct for PCR indel artifacts
      */
     public PairHMMLikelihoodCalculationEngine(final byte constantGCP,
+                                              final PairHMMNativeArguments arguments,
                                               final PairHMM.Implementation hmmType,
                                               final double log10globalReadMismappingRate,
                                               final PCRErrorModel pcrErrorModel) {
-        this( constantGCP, hmmType, log10globalReadMismappingRate, pcrErrorModel, PairHMM.BASE_QUALITY_SCORE_THRESHOLD );
+        this( constantGCP, arguments, hmmType, log10globalReadMismappingRate, pcrErrorModel, PairHMM.BASE_QUALITY_SCORE_THRESHOLD );
     }
 
     /**
@@ -123,6 +125,7 @@ public final class PairHMMLikelihoodCalculationEngine implements ReadLikelihoodC
      *                                  quality.
      */
     public PairHMMLikelihoodCalculationEngine(final byte constantGCP,
+                                              final PairHMMNativeArguments arguments,
                                               final PairHMM.Implementation hmmType,
                                               final double log10globalReadMismappingRate,
                                               final PCRErrorModel pcrErrorModel,
@@ -138,11 +141,11 @@ public final class PairHMMLikelihoodCalculationEngine implements ReadLikelihoodC
         this.constantGCP = constantGCP;
         this.log10globalReadMismappingRate = log10globalReadMismappingRate;
         this.pcrErrorModel = pcrErrorModel;
-        pairHMM = hmmType.makeNewHMM();
+        this.pairHMM = hmmType.makeNewHMM(arguments);
 
         initializePCRErrorModel();
 
-        likelihoodsStream = makeLikelihoodStream();
+        this.likelihoodsStream = makeLikelihoodStream();
 
         if (baseQualityScoreThreshold < QualityUtils.MIN_USABLE_Q_SCORE) {
             throw new IllegalArgumentException("baseQualityScoreThreshold must be greater than or equal to " + QualityUtils.MIN_USABLE_Q_SCORE + " (QualityUtils.MIN_USABLE_Q_SCORE)");

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMNativeArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMNativeArgumentCollection.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.hellbender.tools.walkers.haplotypecaller;
+
+import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
+import org.broadinstitute.barclay.argparser.Argument;
+
+/**
+ * Arguments for native PairHMM implementations
+ */
+public class PairHMMNativeArgumentCollection {
+
+    @Argument(fullName = "nativePairHmmThreads", shortName = "threads", doc="How many threads should a native pairHMM implementation use", optional = true)
+    private int pairHmmNativeThreads = 1;
+
+    @Argument(fullName = "useDoublePrecision", shortName = "useDoublePrecision", doc="use double precision in the native pairHmm. " +
+            "This is slower but matches the java implementation better", optional = true)
+    private boolean useDoublePrecision = false;
+
+    public PairHMMNativeArguments getPairHMMArgs(){
+        final PairHMMNativeArguments args = new PairHMMNativeArguments();
+        args.maxNumberOfThreads = pairHmmNativeThreads;
+        args.useDoublePrecision = useDoublePrecision;
+        return args;
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngineUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/PairHMMLikelihoodCalculationEngineUnitTest.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import htsjdk.samtools.SAMUtils;
 import htsjdk.samtools.TextCigarCodec;
 import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 import org.broadinstitute.hellbender.utils.genotyper.IndexedSampleList;
@@ -118,7 +119,7 @@ public final class PairHMMLikelihoodCalculationEngineUnitTest extends BaseTest {
     @Test(dataProvider = "PcrErrorModelTestProvider", enabled = true)
     public void createPcrErrorModelTest(final String repeat, final int repeatLength) {
 
-        final PairHMMLikelihoodCalculationEngine engine = new PairHMMLikelihoodCalculationEngine((byte)0,
+        final PairHMMLikelihoodCalculationEngine engine = new PairHMMLikelihoodCalculationEngine((byte)0, new PairHMMNativeArguments(),
                 PairHMM.Implementation.ORIGINAL, 0.0,
                 PairHMMLikelihoodCalculationEngine.PCRErrorModel.CONSERVATIVE);
 
@@ -165,7 +166,7 @@ public final class PairHMMLikelihoodCalculationEngineUnitTest extends BaseTest {
 
         PairHMMLikelihoodCalculationEngine.writeLikelihoodsToFile = true;
 
-        final ReadLikelihoodCalculationEngine lce = new PairHMMLikelihoodCalculationEngine((byte) SAMUtils.MAX_PHRED_SCORE,
+        final ReadLikelihoodCalculationEngine lce = new PairHMMLikelihoodCalculationEngine((byte) SAMUtils.MAX_PHRED_SCORE, new PairHMMNativeArguments(),
                 PairHMM.Implementation.LOGLESS_CACHING, MathUtils.logToLog10(QualityUtils.qualToErrorProbLog10(LEAC.phredScaledGlobalReadMismappingRate)),
                 PairHMMLikelihoodCalculationEngine.PCRErrorModel.CONSERVATIVE);
 


### PR DESCRIPTION
...and added CLI parameters for this interface.

This code has the changes corresponding to [PR #2574](https://github.com/broadinstitute/gatk/pull/2574) from [broadinstitute/gatk](https://github.com/broadinstitute/gatk).

The changes are pretty much exactly those from the [lb_connect_pairhmmargs](https://github.com/broadinstitute/gatk-protected/tree/lb_connect_pairhmmargs) branch, which, apparently, never got merged. The main difference is the referenced snapshot version of gatk ([4.alpha.2-226-gfade3c6-20170420.222947-1](https://artifactory.broadinstitute.org/artifactory/libs-snapshot/org/broadinstitute/gatk/4.alpha.2-226-gfade3c6-SNAPSHOT/)), which contains the changes from the PR referenced above.