### PR TITLE
Rev gatk-public to 4.alpha.2-234-gc3a44c9-20170427.144324-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ build.dependsOn installDist
 check.dependsOn installDist
 
 // NOTE: When changing the GATK version, these versions should be changed to specify the same version as used by GATK
-final gatkVersion = '4.alpha.2-233-g93dea7d-20170426.180236-1'
+final gatkVersion = '4.alpha.2-234-gc3a44c9-20170427.144324-1'
 final htsjdkVersion = '2.9.1'
 final testNGVersion = '6.11'
 


### PR DESCRIPTION
This snapshot includes a change to make it easier to use GenotypeGVCFs
with GenomicsDB input: JSON files no longer need to be explicitly
provided on the command line.