### PR TITLE
fixing ClassCastException  when running GenotypeGVCFs against GenomicsDB

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/ReferenceConfidenceVariantContextMerger.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/ReferenceConfidenceVariantContextMerger.java
@@ -259,7 +259,6 @@ final class ReferenceConfidenceVariantContextMerger {
      * lookup the depth from the VC DP field or calculate by summing the depths of the genotypes
      */
     private static int calculateVCDepth(VariantContext vc) {
-
         if ( vc.hasAttribute(VCFConstants.DEPTH_KEY) ) {
             return vc.getAttributeAsInt(VCFConstants.DEPTH_KEY, 0);
         } else { // handle the gVCF case from the HaplotypeCaller
@@ -287,9 +286,10 @@ final class ReferenceConfidenceVariantContextMerger {
         return attributes;
     }
 
-    private static int getBestDepthValue(final Genotype gt) {
+    @VisibleForTesting
+    static int getBestDepthValue(final Genotype gt) {
         if (gt.hasExtendedAttribute(GATKVCFConstants.MIN_DP_FORMAT_KEY)) {
-            return Integer.parseInt((String) gt.getAnyAttribute(GATKVCFConstants.MIN_DP_FORMAT_KEY));
+            return Integer.parseInt(gt.getAnyAttribute(GATKVCFConstants.MIN_DP_FORMAT_KEY).toString());
         } else {
             return gt.hasDP() ? gt.getDP() : 0;
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/ReferenceConfidenceVariantContextMergerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/ReferenceConfidenceVariantContextMergerUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.walkers;
 
 import htsjdk.samtools.util.Locatable;
 import htsjdk.variant.variantcontext.*;
+import htsjdk.variant.vcf.VCFConstants;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.Utils;
@@ -46,6 +47,23 @@ public class ReferenceConfidenceVariantContextMergerUnitTest extends BaseTest {
             VariantContextTestUtils.assertGenotypesAreEqual(result.getGenotype(expectedGenotype.getSampleName()), expectedGenotype);
         }
     }
+
+    @DataProvider
+    public Object[][] getVariousDepths() {
+        Genotype baseGenotype = new GenotypeBuilder("sample", Arrays.asList(C, G)).make();
+        return new Object[][]{
+                {baseGenotype, 0},
+                {new GenotypeBuilder(baseGenotype).DP(10).attribute(GATKVCFConstants.MIN_DP_FORMAT_KEY, 5).make(), 5},
+                {new GenotypeBuilder(baseGenotype).DP(10).attribute(GATKVCFConstants.MIN_DP_FORMAT_KEY, "5").make(), 5},
+                {new GenotypeBuilder(baseGenotype).DP(10).make(), 10}
+        };
+    }
+
+    @Test(dataProvider = "getVariousDepths")
+    public void testGetBestDepthValue(final Genotype genotype, final int expectedDepth){
+        Assert.assertEquals(ReferenceConfidenceVariantContextMerger.getBestDepthValue(genotype), expectedDepth);
+    }
+
 
     @Test
     public void testGenerateADWithNewAlleles() {


### PR DESCRIPTION
fixing a site in ReferenceConfidenceVariantContextMerger where a String
was expected but an Integer was being provided in some circumstances

GenomicsDB creates variants with MIN_DP as an integer instead of a String which was causing a ClassCastException

should fix #1014, but I don't have access yet to the files that produced the error so I can't check