### PR TITLE
Rev gatk-public dependency to 4.alpha.2-236-g1dde31b-20170427.202410-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ build.dependsOn installDist
 check.dependsOn installDist
 
 // NOTE: When changing the GATK version, these versions should be changed to specify the same version as used by GATK
-final gatkVersion = '4.alpha.2-234-gc3a44c9-20170427.144324-1'
+final gatkVersion = '4.alpha.2-236-g1dde31b-20170427.202410-1'
 final htsjdkVersion = '2.9.1'
 final testNGVersion = '6.11'
 


### PR DESCRIPTION
This brings in a bug fix to the FS annotation to make it match R,
as well as some GenomicsDB-related test utilities.