### PR TITLE
making GenotypeGVCFs write index files

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
@@ -164,7 +164,7 @@ public final class GenotypeGVCFs extends VariantWalker {
             VCFStandardHeaderLines.addStandardInfoLines(headerLines, true, VCFConstants.DBSNP_KEY);
         }
 
-        vcfWriter = GATKVariantContextUtils.createVCFWriter(outputFile, getReferenceDictionary(), false);
+        vcfWriter = createVCFWriter(outputFile);
 
         final Set<String> sampleNameSet = samples.asSetOfSamples();
         final VCFHeader vcfHeader = new VCFHeader(headerLines, new TreeSet<>(sampleNameSet));


### PR DESCRIPTION
it previously didn't honor the engine arguments for creating index files but it does now

fixes broadinstitute/gatk#2635