### PR TITLE
Isolate a problematic change to ReferenceConfidenceModel for further discussion

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/ReferenceConfidenceModel.java
@@ -213,8 +213,9 @@ public final class ReferenceConfidenceModel {
         // as our GLs for the site.
         final GenotypeLikelihoods leastConfidenceGLs = getGLwithWorstGQ(indelGLs, snpGLs);
 
-        gb.GQ((int) (-10 * getGQForHomRef(leastConfidenceGLs)));
-        gb.PL(leastConfidenceGLs.getAsPLs());
+        final int[] leastConfidenceGLsAsPLs = leastConfidenceGLs.getAsPLs();
+        gb.GQ(GATKVariantContextUtils.calculateGQFromPLs(leastConfidenceGLsAsPLs));
+        gb.PL(leastConfidenceGLsAsPLs);
 
         vcb.genotypes(gb.make());
         return vcb.make();


### PR DESCRIPTION
I've extracted this change to ReferenceConfidenceModel from the now-closed PR
https://github.com/broadinstitute/gatk-protected/pull/1022, since it causes `HaplotypeCaller` tests
to fail spectacularly (including concordance tests against GATK3), so that we can
unblock the badly-needed merge of https://github.com/broadinstitute/gatk-protected/pull/1027

Let's review and test this change in isolation to be sure we understand it fully
before accepting it into master.