### PR TITLE
Add ability to generate tool documentation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -280,32 +280,37 @@ javadoc {
 }
 
 // Generate GATK Online Doc
-task gatkDoc(type: Javadoc, dependsOn: classes) {
+task gatkDoc(type: Javadoc, dependsOn: ['cleanGatkDoc', classes]) {
+    // A GATK source folder is required to resolve any dependent classes that will be part of the generated doc.
+    final String gatkSourceDir = project.hasProperty('gatkSourceDir') ?
+            project.getProperty('gatkSourceDir') :
+            '../gatk'
     final File gatkDocDir = new File("build/docs/gatkdoc")
-    String gatkSourceDir;
+    final String pathToGATKClasses = gatkSourceDir + '/src/main/java/org/broadinstitute/hellbender/'
+    final String pathToGATKHelpTemplates = gatkSourceDir + '/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/'
     doFirst {
         // make sure the output folder exists or we can create it
         if (!gatkDocDir.exists() && !gatkDocDir.mkdirs()) {
-            throw new GradleException(String.format("Failure creating folder (%s) for GATK doc output in task (%s)",
+            throw new InvalidUserDataException(String.format("Failure creating folder (%s) for GATK doc output in task (%s)",
                     gatkDocDir.getAbsolutePath(),
                     it.name));
         }
-        // In order to generate docs for gatk-protected, a GATK source folder is required to resolve any dependent
-        // classes that will be part of the generated doc.
-        gatkSourceDir = project.hasProperty('gatkSourceDir') ?
-                project.getProperty('gatkSourceDir') :
-                '../gatk'
         if (!file(gatkSourceDir).exists()) {
             throw new GradleException("A GATK source directory is required to generate doc for gatk-protected: "
                     + gatkSourceDir + ". Set the gatkSourceDir property to the GATK source directory.")
         }
+        println("Note: The GATK source folder must contain the same version of GATK that is used to build gatk-protected")
     }
 
-    // We need to add the source for any GATK classes that are referenced by the local DocumentedFeatures
-    source = sourceSets.main.allJava +
-            files { file(gatkSourceDir + '/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections').listFiles() } +
-            files { file(gatkSourceDir + '/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/').listFiles() } +
-            files { file(gatkSourceDir + '/src/main/java/org/broadinstitute/hellbender/engine/filters/').listFiles() }
+    //The source set needs to include any GATK classes that are referenced by the local DocumentedFeatures
+    final String gatkArgCollections = pathToGATKClasses + 'cmdline/argumentcollections/'
+    final String gatkPlugins = pathToGATKClasses + 'cmdline/GATKPlugin/'
+    final String gatkFilters = pathToGATKClasses + 'engine/filters/'
+    final FileCollection gatkClassFiles =
+                    files { file(gatkArgCollections).listFiles() } +
+                    files { file(gatkPlugins).listFiles() } +
+                    files { file(gatkFilters).listFiles() }
+    source = sourceSets.main.allJava + gatkClassFiles
 
     // The gatkDoc process instantiates any documented feature classes, so to run it we need the entire
     // runtime classpath, as well as jdk javadoc files such as tools.jar, where com.sun.javadoc lives.
@@ -316,7 +321,7 @@ task gatkDoc(type: Javadoc, dependsOn: classes) {
     outputs.dir(gatkDocDir)
     options.destinationDirectory(gatkDocDir)
 
-    options.addStringOption("settings-dir", "src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates");
+    options.addStringOption("settings-dir", pathToGATKHelpTemplates);
     options.addStringOption("output-file-extension", "html")
     options.addStringOption("absolute-version", getVersion())
     options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ applicationDefaultJvmArgs = ["-Dsamjdk.use_async_io_read_samtools=false","-Dsamj
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.internal.os.OperatingSystem
+import javax.tools.ToolProvider
 
 def isMacOsX = OperatingSystem.current().macOsX
 def customJarPath = hasProperty("custom.jar.dir") ? property("custom.jar.dir") : null;
@@ -81,9 +82,18 @@ final gatkVersion = '4.alpha.2-260-ge8d00ca-20170508.215840-1'
 final htsjdkVersion = '2.9.1'
 final testNGVersion = '6.11'
 
+// Get the jdk files we need to run javadoc. We need to use these during compile, testCompile,
+// test execution, and gatkDoc generation, but we don't want them as part of the runtime
+// classpath and we don't want to redistribute them in the uber jar.
+final javadocJDKFiles = files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs())
+
 dependencies {
     compile 'org.broadinstitute:gatk:' + gatkVersion
     compile 'org.broadinstitute:hdf5-java-bindings:1.1.0-hdf5_2.11.0'
+
+    // javadoc utilities; compile/test only to prevent redistribution of sdk jars
+    compileOnly(javadocJDKFiles)
+    testCompile(javadocJDKFiles)
 
     testCompile 'org.testng:testng:' + testNGVersion
 }
@@ -256,6 +266,61 @@ test {
 
 task wrapper(type: Wrapper) {
     gradleVersion = '3.1'
+}
+
+tasks.withType(Javadoc) {
+    // do this for all javadoc tasks, inlcuding gatkDoc
+    options.addStringOption('Xdoclint:none')
+}
+
+javadoc {
+    // This is a hack to disable the java 8 default javadoc lint until we fix the html formatting
+    // We only want to do this for the javadoc task, not gatkDoc
+    options.addStringOption('Xdoclint:none', '-quiet')
+}
+
+// Generate GATK Online Doc
+task gatkDoc(type: Javadoc, dependsOn: classes) {
+    final File gatkDocDir = new File("build/docs/gatkdoc")
+    String gatkSourceDir;
+    doFirst {
+        // make sure the output folder exists or we can create it
+        if (!gatkDocDir.exists() && !gatkDocDir.mkdirs()) {
+            throw new GradleException(String.format("Failure creating folder (%s) for GATK doc output in task (%s)",
+                    gatkDocDir.getAbsolutePath(),
+                    it.name));
+        }
+        // In order to generate docs for gatk-protected, a GATK source folder is required to resolve any dependent
+        // classes that will be part of the generated doc.
+        gatkSourceDir = project.hasProperty('gatkSourceDir') ?
+                project.getProperty('gatkSourceDir') :
+                '../gatk'
+        if (!file(gatkSourceDir).exists()) {
+            throw new GradleException("A GATK source directory is required to generate doc for gatk-protected: "
+                    + gatkSourceDir + ". Set the gatkSourceDir property to the GATK source directory.")
+        }
+    }
+
+    // We need to add the source for any GATK classes that are referenced by the local DocumentedFeatures
+    source = sourceSets.main.allJava +
+            files { file(gatkSourceDir + '/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections').listFiles() } +
+            files { file(gatkSourceDir + '/src/main/java/org/broadinstitute/hellbender/cmdline/GATKPlugin/').listFiles() } +
+            files { file(gatkSourceDir + '/src/main/java/org/broadinstitute/hellbender/engine/filters/').listFiles() }
+
+    // The gatkDoc process instantiates any documented feature classes, so to run it we need the entire
+    // runtime classpath, as well as jdk javadoc files such as tools.jar, where com.sun.javadoc lives.
+    classpath = sourceSets.main.runtimeClasspath + javadocJDKFiles
+    options.docletpath = classpath.asType(List)
+    options.doclet = "org.broadinstitute.hellbender.utils.help.GATKHelpDoclet"
+
+    outputs.dir(gatkDocDir)
+    options.destinationDirectory(gatkDocDir)
+
+    options.addStringOption("settings-dir", "src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates");
+    options.addStringOption("output-file-extension", "html")
+    options.addStringOption("absolute-version", getVersion())
+    options.addStringOption("build-timestamp", new Date().format("dd-mm-yyyy hh:mm:ss"))
+    options.addStringOption("verbose")
 }
 
 tasks.withType(ShadowJar) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/copynumber/CollectAllelicCounts.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.util.IntervalList;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CreateAllelicPanelOfNormals.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CreateAllelicPanelOfNormals.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.exome;
 
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hdf5.HDF5File;
 import org.broadinstitute.hdf5.HDF5Library;
 import org.broadinstitute.barclay.argparser.Argument;
@@ -30,6 +31,7 @@ import java.util.List;
         oneLineSummary = "Creates an allelic panel of normals",
         programGroup = CopyNumberProgramGroup.class
 )
+@DocumentedFeature
 public final class CreateAllelicPanelOfNormals extends CommandLineProgram {
     protected static final String SITE_FREQUENCY_THRESHOLD_SHORT_NAME = "f";
     protected static final String SITE_FREQUENCY_THRESHOLD_LONG_NAME = "siteFrequencyThreshold";

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/GetBayesianHetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/GetBayesianHetCoverage.java
@@ -8,6 +8,7 @@ import org.broadinstitute.barclay.argparser.*;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.ReferenceInputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.RequiredReferenceInputArgumentCollection;
@@ -54,6 +55,7 @@ import java.io.File;
         oneLineSummary = "Call heterozygous sites and output information about the called sites",
         programGroup = CopyNumberProgramGroup.class
 )
+@DocumentedFeature
 public final class GetBayesianHetCoverage extends CommandLineProgram {
 
     private final Logger logger = LogManager.getLogger(GetBayesianHetCoverage.class);

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/GetHetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/GetHetCoverage.java
@@ -6,6 +6,7 @@ import org.broadinstitute.barclay.argparser.*;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.ReferenceInputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.RequiredReferenceInputArgumentCollection;
@@ -29,6 +30,7 @@ import java.io.File;
         oneLineSummary = "Output ref/alt counts at heterozygous SNPs in normal sample (and at same sites in tumor sample, if specified)",
         programGroup = CopyNumberProgramGroup.class
 )
+@DocumentedFeature
 public final class GetHetCoverage extends CommandLineProgram {
 
     protected static final String PVALUE_THRESHOLD_FULL_NAME = "pvalueThreshold";

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/GenotypeGVCFs.java
@@ -9,6 +9,7 @@ import org.broadinstitute.barclay.argparser.Advanced;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.DbsnpArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
@@ -65,6 +66,7 @@ import java.util.*;
  *
  */
 @CommandLineProgramProperties(summary = "genotype a gvcf file to produce a vcf", oneLineSummary = "genotype a gvcf file", programGroup = VariantProgramGroup.class)
+@DocumentedFeature
 public final class GenotypeGVCFs extends VariantWalker {
 
     public static final String PHASED_HOM_VAR_STRING = "1|1";

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCaller.java
@@ -6,6 +6,7 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.ReferenceInputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
@@ -152,6 +153,7 @@ import java.util.List;
         oneLineSummary = "Call germline SNPs and indels via local re-assembly of haplotypes",
         programGroup = VariantProgramGroup.class
 )
+@DocumentedFeature
 public final class HaplotypeCaller extends AssemblyRegionWalker {
 
     public static final int DEFAULT_READSHARD_SIZE = 5000;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/Mutect2.java
@@ -7,6 +7,7 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
@@ -90,6 +91,7 @@ import java.util.List;
         oneLineSummary = "Call somatic SNPs and indels via local re-assembly of haplotypes",
         programGroup = VariantProgramGroup.class
 )
+@DocumentedFeature
 public final class Mutect2 extends AssemblyRegionWalker {
 
     @ArgumentCollection

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/common.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/common.html
@@ -1,0 +1,65 @@
+<#--
+        This file contains part of the theming neccesary to present GATKDocs on the GATK website. Included are the
+        paths to our bootstrap assets as well as helper functions to generate relevant links. Styling is separated
+        out, so pages will be minimalistic html unless replacement styling is provided.
+
+        -->
+
+    <#global siteRoot = "http://www.broadinstitute.org/gatk/" />
+    <#global guideIndex = "http://www.broadinstitute.org/gatk/guide/" />
+    <#global forum = "http://gatkforums.broadinstitute.org/" />
+
+    <#macro footerInfo>
+        <hr>
+        <p><a href='#top'><i class='fa fa-chevron-up'></i> Return to top</a></p>
+        <hr>
+        <p class="see-also">See also 
+        	<a href="${guideIndex}">GATK Documentation Index</a> |
+        	<a href="index">Tool Docs Index</a> |
+        	<a href="${forum}">Support Forum</a>
+        </p>
+
+        <p class="version">GATK version ${version} built at ${timestamp}.
+        <#-- closing P tag in next macro -->
+    </#macro>
+    
+    <#macro footerClose>
+    	<#-- ugly little hack to enable adding tool-specific info inline -->
+        </p>
+    </#macro>
+
+    <#macro getCategories groups>
+        <style>
+            #sidenav .accordion-body a {
+                color : gray;
+            }
+
+            .accordion-body li {
+                list-style : none;
+            }
+        </style>
+        <ul class="nav nav-pills nav-stacked" id="sidenav">
+        	<#assign seq = ["engine", "tools", "other", "utilities"]>
+        	<#list seq as supercat>
+        		<hr>
+        		<#list groups?sort_by("name") as group>
+        			<#if group.supercat == supercat>
+						<li><a data-toggle="collapse" data-parent="#sidenav" href="#${group.id}">${group.name}</a>
+							<div id="${group.id}"
+								<?php echo ($group == '${group.name}')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
+								<ul>
+									<#list data as datum>
+										<#if datum.group == group.name>
+											<li>
+												<a href="${datum.filename}">${datum.name}</a>
+											</li>
+										</#if>
+									</#list>
+								</ul>
+							</div>
+						</li>
+        			</#if>
+        		</#list>
+        	</#list>
+        </ul>
+    </#macro>

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.index.template.html
@@ -1,0 +1,70 @@
+<?php
+
+    include '../../../common/include/common.php';
+    include_once '../../config.php';
+    $module = modules::GATK;
+    printHeader($module, "GATK | Tool Documentation Index", "Guide");
+?>
+
+<div class='row-fluid'>
+
+<?php printGATKDocsNav($module); ?>
+
+<div class='span9'>
+
+<#include "common.html"/>
+
+<#macro emitGroup group>
+    <div class="accordion-group">
+        <div class="accordion-heading">
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#index" href="#${group.id}">
+                <h4>${group.name}</h4>
+            </a>
+        </div>
+        <div class="accordion-body collapse" id="${group.id}">
+            <div class="accordion-inner">
+                <p class="lead">${group.summary}</p>
+                <table class="table table-striped table-bordered table-condensed">
+                    <tr>
+                        <th>Name</th>
+                        <th>Summary</th>
+                    </tr>
+                    <#list data as datum>
+                        <#if datum.group == group.name>
+                            <tr>
+                                <td><a href="${datum.filename}">${datum.name}</a></td>
+                                <td>${datum.summary}</td>
+                            </tr>
+                        </#if>
+                    </#list>
+                </table>
+            </div>
+        </div>
+    </div>
+</#macro>
+
+<h1 id="top">GATK Tool Documentation Index
+    <small>${version}</small>
+</h1>
+<div class="accordion" id="index">
+    <#assign seq = ["engine", "tools", "other", "utilities"]>
+	<#list seq as supercat>
+		<br />
+		<#list groups?sort_by("name") as group>
+			<#if group.supercat == supercat>
+				<@emitGroup group=group/>
+			</#if>
+		</#list>
+	</#list>
+</div>
+
+<@footerInfo />
+<@footerClose />
+
+</div></div>
+
+<?php
+
+    printFooter($module);
+
+?>

--- a/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/hellbender/utils/helpTemplates/generic.template.html
@@ -1,0 +1,188 @@
+<?php
+
+    include '../../../common/include/common.php';
+    include_once '../../config.php';
+    $module = modules::GATK;
+    printHeader($module, "GATK | Tool Documentation Index", "Guide");
+?>
+
+<div class='row-fluid' id="top">
+
+	<#include "common.html"/>
+
+	<#macro argumentlist name myargs>
+		<#if myargs?size != 0>
+			<tr>
+				<th colspan="4" id="row-divider">${name}</th>
+			</tr>
+			<#list myargs as arg>
+				<tr>
+					<td><a href="#${arg.name}">${arg.name}</a><br />
+						<#if arg.synonyms != "NA">
+							<#if arg.name[2..] != arg.synonyms[1..]>
+								&nbsp;<em>${arg.synonyms}</em>
+							</#if>
+						</#if>
+					</td>
+					<!--<td>${arg.type}</td> -->
+					<td>${arg.defaultValue!"NA"}</td>
+					<td>${arg.summary}</td>
+				</tr>
+			</#list>
+		</#if>
+	</#macro>
+
+	<#macro argumentDetails arg>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="${arg.name}">${arg.name} </a>
+			<#if arg.synonyms??> / <small>${arg.synonyms}</small></#if>
+		</h3>
+		<p class="args">
+			<b>${arg.summary}</b><br />
+			${arg.fulltext}
+		</p>
+		<#if arg.otherArgumentRequired != "NA">
+			<p><b>Dependency:</b> This argument requires that you also specify <code>${arg.otherArgumentRequired}</code>.</p>
+		</#if>
+		<#if arg.exclusiveOf != "NA">
+			<p><b>Exclusion:</b> This argument cannot be used at the same time as <code>${arg.exclusiveOf}</code>.</p>
+		</#if>
+		<#if arg.options?has_content>
+			<p>
+				The ${arg.name} argument is an enumerated type (${arg.type}), which can have one of the following values:
+			<dl class="enum">
+				<#list arg.options as option>
+					<dt class="enum">${option.name}</dt>
+					<dd class="enum">${option.summary}</dd>
+				</#list>
+			</dl>
+			</p>
+		</#if>
+		<p><#if arg.required != "NA">
+			<#if arg.required == "yes">
+				<span class="badge badge-important">R</span>
+			</#if>
+		</#if>
+		<span class="label label-info ">${arg.type}</span>
+		<#if arg.defaultValue?has_content>
+			&nbsp;<span class="label">${arg.defaultValue}</span>
+		</#if>
+		<#if arg.minValue?is_number>
+			&nbsp;<span class="label label-warning">[ [ ${arg.minValue}</span>
+		</#if>
+		<#if arg.minRecValue?is_number>
+			&nbsp;<span class="label label-success">[ ${arg.minRecValue}</span>
+		</#if>
+		<#if arg.maxRecValue?is_number>
+			&nbsp;<span class="label label-success">${arg.maxRecValue} ]</span>
+		</#if>
+		<#if arg.maxValue?is_number>
+			&nbsp;<span class="label label-warning">${arg.maxValue} ] ]</span>
+		</#if>
+		</p>
+	</#macro>
+
+	<?php $group = '${group}'; ?>
+
+	<section class="span4">
+		<aside class="well">
+			<a href="index"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
+		</aside>
+		<aside class="well">
+			<h2>Categories</h2>
+			<@getCategories groups=groups />
+		</aside>
+		<?php getForumPosts( '${name}' ) ?>
+
+	</section>
+
+	<div class="span8">
+
+		<h1>${name}</h1>
+
+		<p class="lead">${summary}</p>
+
+		<#if group?? >
+			<h3>Category
+				<small> ${group}</small>
+			</h3>
+		</#if>
+		<#if walkertype?? && walkertype != "">
+			<h3>Traversal
+				<small>${walkertype}</small>
+			</h3>
+		</#if>
+		<hr>
+		<h2>Overview</h2>
+		${description}
+
+		<#-- Create references to additional capabilities if appropriate -->
+			<#if readFilter?? && readFilter?size != 0>
+				<hr>
+				<h2>Additional Information</h2>
+				<p></p>
+			</#if>
+			<#if readFilter?? && readFilter?size != 0>
+				<h3>Read filters</h3>
+				<#if readFilter?size = 1>
+					<p>This Read Filter is automatically applied to the data by the Engine before processing by ${name}.</p>
+				</#if>
+				<#if (readFilter?size > 1) >
+					<p>These Read Filters are automatically applied to the data by the Engine before processing by ${name}.</p>
+				</#if>
+				<ul>
+					<#list readFilter as filter>
+						<li><a href="${filter.filename}">${filter.name}</a></li>
+					</#list>
+				</ul>
+			</#if>
+			<#if extradocs?size != 0>
+				<h3>Additional references</h3>
+				<p>See these additional references.</p>
+				<ul>
+					<#list extradocs as extradoc>
+						<li><a href="${extradoc.filename}">${extradoc.name}</a></li>
+					</#list>
+				</ul>
+			</#if>
+
+			<#-- Create the argument summary -->
+			<#if arguments.all?size != 0>
+				<h3>${name} specific arguments</h3>
+				<p>This table summarizes the command-line arguments that are specific to this tool. For more details on each argument, see the list further down below the table or click on an argument name to jump directly to that entry in the list.</p>
+				<table class="table table-striped table-bordered table-condensed">
+					<thead>
+					<tr>
+						<th>Argument name(s)</th>
+						<th>Default value</th>
+						<th>Summary</th>
+					</tr>
+					</thead>
+					<tbody>
+					<@argumentlist name="Positional Arguments" myargs=arguments.positional/>
+					<@argumentlist name="Required Arguments" myargs=arguments.required/>
+					<@argumentlist name="Optional Tool Arguments" myargs=arguments.optional/>
+					<@argumentlist name="Optional Common Arguments" myargs=arguments.common/>
+					<@argumentlist name="Advanced Arguments" myargs=arguments.advanced/>
+					<@argumentlist name="Hidden Arguments" myargs=arguments.hidden/>
+					<@argumentlist name="Deprecated Arguments" myargs=arguments.deprecated/>
+					</tbody>
+				</table>
+			</#if>
+
+			<#-- List all of the things -->
+			<#if arguments.all?size != 0>
+				<#-- Create the argument details -->
+					<h3>Argument details</h3>
+					<p>Arguments in this list are specific to this tool. Keep in mind that other arguments are available that are shared with other tools (e.g. command-line GATK arguments); see Inherited arguments above.</p>
+					<#list arguments.all as arg>
+						<@argumentDetails arg=arg/>
+					</#list>
+			</#if>
+
+			<@footerInfo />
+			<@footerClose />
+
+	</div>
+
+	<?php printFooter($module); ?>


### PR DESCRIPTION
Until we resolve how we're going to integrate gatk-protected doc with gatk-public, the comms team needs a way to generate/review doc for protected tools. This PR adds the same docgen process we use for public, with the exception that you also need to have a GATK clone to run it, since javadoc from any dependent engine classes needs to be available.

I also tagged a handful of tools with @DocumentedFeatureObject so I could test the process manually.