### PR TITLE
separate emitting from filtering based on tumor lod

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2ArgumentCollection.java
@@ -81,8 +81,8 @@ public class M2ArgumentCollection extends AssemblyBasedCallerArgumentCollection 
     /**
      * Only variants with tumor LODs exceeding this threshold can pass filtering.
      */
-    @Argument(fullName = "tumor_lod", optional = true, doc = "LOD threshold for calling tumor variant")
-    public double TUMOR_LOD_THRESHOLD = 5.3;
+    @Argument(fullName = "tumor_lod_to_emit", optional = true, doc = "LOD threshold for emit tumor variant")
+    public double emissionLodThreshold = 3.0;
 
     /**
      * This is a measure of the minimum evidence to support that a variant observed in the tumor is not also present in the normal.

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/M2FiltersArgumentCollection.java
@@ -11,6 +11,12 @@ public class M2FiltersArgumentCollection extends AssemblyBasedCallerArgumentColl
     private static final long serialVersionUID = 9345L;
 
     /**
+     * Only variants with tumor LODs exceeding this threshold can pass filtering.
+     */
+    @Argument(fullName = "tumor_lod", optional = true, doc = "LOD threshold for calling tumor variant")
+    public double TUMOR_LOD_THRESHOLD = 5.3;
+
+    /**
      * This is a measure of the minimum evidence to support that a variant observed in the tumor is not also present in the normal
      * as an artifact i.e. not as a germline event.
      */

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/mutect/SomaticGenotypingEngine.java
@@ -130,7 +130,7 @@ public class SomaticGenotypingEngine extends AssemblyBasedCallerGenotypingEngine
             final Optional<PerAlleleCollection<Double>> normalArtifactLog10Odds = getForNormal(() -> somaticLog10Odds(log10NormalMatrix.get()));
 
             final List<Allele> somaticAltAlleles = mergedVC.getAlternateAlleles().stream()
-                    .filter(allele -> tumorLog10Odds.getAlt(allele) > MTAC.TUMOR_LOD_THRESHOLD)
+                    .filter(allele -> tumorLog10Odds.getAlt(allele) > MTAC.emissionLodThreshold)
                     .filter(allele -> !hasNormal || normalLog10Odds.get().getAlt(allele) > MTAC.NORMAL_LOD_THRESHOLD)
                     .collect(Collectors.toList());
             final List<Allele> allSomaticAlleles = ListUtils.union(Arrays.asList(mergedVC.getReference()), somaticAltAlleles);


### PR DESCRIPTION
@takutosato This change will emit and then filter variants with low but not too low tumor lods.  This will be useful for analyzing false negatives and making ROC curves.