### PR TITLE
ImmutableComputableGraph code improvement + unit tests

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/CoverageModelArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/CoverageModelArgumentCollection.java
@@ -124,6 +124,10 @@ public final class CoverageModelArgumentCollection {
     public static final String NUM_LATENTS_SHORT_NAME = "NL";
     public static final String NUM_LATENTS_LONG_NAME = "numLatents";
 
+    public static final int DEFAULT_NUMBER_OF_TARGET_SPACE_PARTITIONS = 1;
+    public static final String NUMBER_OF_TARGET_SPACE_PARTITIONS_SHORT_NAME = "NTSP";
+    public static final String NUMBER_OF_TARGET_SPACE_PARTITIONS_LONG_NAME = "numTargetSpacePartitions";
+
     public static final int DEFAULT_MIN_LEARNING_READ_COUNT = 5;
     public static final String MIN_LEARNING_READ_COUNT_SHORT_NAME = "MLRC";
     public static final String MIN_LEARNING_READ_COUNT_LONG_NAME = "minimumLearningReadCount";
@@ -200,7 +204,6 @@ public final class CoverageModelArgumentCollection {
     public static final String TARGET_SPECIFIC_VARIANCE_SOLVER_NUM_THREADS_SHORT_NAME = "TSVSNT";
     public static final String TARGET_SPECIFIC_VARIANCE_SOLVER_NUM_THREADS_LONG_NAME = "targetSpecificVarianceSolverNumThreads";
 
-
     /* bias covariates related */
 
     public static final BiasCovariateSolverStrategy DEFAULT_BIAS_COVARIATES_SOLVER_TYPE = BiasCovariateSolverStrategy.SPARK;
@@ -276,6 +279,8 @@ public final class CoverageModelArgumentCollection {
     public static final String FOURIER_REGULARIZATION_STRENGTH_LONG_NAME = "fourierRegularizationStrength";
 
 
+    /* copy ratio calling related */
+
     public static final boolean DEFAULT_CR_UPDATE_ENABLED = true;
     public static final String CR_UPDATE_ENABLED_SHORT_NAME = "CRU";
     public static final String CR_UPDATE_ENABLED_LONG_NAME = "copyRatioUpdate";
@@ -284,10 +289,7 @@ public final class CoverageModelArgumentCollection {
     public static final String CR_HMM_TYPE_SHORT_NAME = "CRHMM";
     public static final String CR_HMM_TYPE_LONG_NAME = "copyRatioHMMType";
 
-
-    public static final int DEFAULT_NUMBER_OF_TARGET_SPACE_PARTITIONS = 1;
-    public static final String NUMBER_OF_TARGET_SPACE_PARTITIONS_SHORT_NAME = "NTSP";
-    public static final String NUMBER_OF_TARGET_SPACE_PARTITIONS_LONG_NAME = "numTargetSpacePartitions";
+    /* checkpointing related */
 
     public static final int DEFAULT_RDD_CHECKPOINTING_INTERVAL = 10;
     public static final String RDD_CHECKPOINTING_INTERVAL_SHORT_NAME = "RDDCPI";
@@ -300,7 +302,6 @@ public final class CoverageModelArgumentCollection {
     public static final String DEFAULT_RDD_CHECKPOINTING_PATH = "/dev/null";
     public static final String RDD_CHECKPOINTING_PATH_SHORT_NAME = "RDDCPP";
     public static final String RDD_CHECKPOINTING_PATH_LONG_NAME = "rddCheckpointingPath";
-
 
     public static final int DEFAULT_RUN_CHECKPOINTING_INTERVAL = 1;
     public static final String RUN_CHECKPOINTING_INTERVAL_SHORT_NAME = "RCPI";

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/CoverageModelEMComputeBlock.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/CoverageModelEMComputeBlock.java
@@ -183,33 +183,33 @@ public final class CoverageModelEMComputeBlock {
                                                                   final boolean ardEnabled) {
         Utils.validateArg(!ardEnabled || biasCovariatesEnabled, "If ARD is enabled, bias covariates must be" +
                 " enabled as well");
-        final ImmutableComputableGraph.ImmutableComputableGraphBuilder cgbuilder =
+        final ImmutableComputableGraphUtils.ImmutableComputableGraphBuilder cgbuilder =
                 ImmutableComputableGraph.builder();
         /*
          * Data nodes
          */
         cgbuilder
                 /* raw read counts */
-                .addNDArrayPrimitiveNode(CoverageModelICGCacheNode.n_st.name())
+                .primitiveNodeWithEmptyNDArray(CoverageModelICGCacheNode.n_st.name())
                 /* mask */
-                .addNDArrayPrimitiveNode(CoverageModelICGCacheNode.M_st.name())
+                .primitiveNodeWithEmptyNDArray(CoverageModelICGCacheNode.M_st.name())
                 /* mapping error probability */
-                .addNDArrayPrimitiveNode(CoverageModelICGCacheNode.err_st.name());
+                .primitiveNodeWithEmptyNDArray(CoverageModelICGCacheNode.err_st.name());
 
         /*
          * Model parameters
          */
         cgbuilder
                 /* mean log bias */
-                .addNDArrayPrimitiveNode(CoverageModelICGCacheNode.m_t.name())
+                .primitiveNodeWithEmptyNDArray(CoverageModelICGCacheNode.m_t.name())
                 /* unexplained variance */
-                .addNDArrayPrimitiveNode(CoverageModelICGCacheNode.Psi_t.name());
+                .primitiveNodeWithEmptyNDArray(CoverageModelICGCacheNode.Psi_t.name());
 
         /* if ARD is enabled, add a node for ARD coefficients */
         if (ardEnabled) {
             cgbuilder
                     /* precision of bias covariates */
-                    .addNDArrayPrimitiveNode(CoverageModelICGCacheNode.alpha_l.name());
+                    .primitiveNodeWithEmptyNDArray(CoverageModelICGCacheNode.alpha_l.name());
         }
 
         /*
@@ -217,24 +217,24 @@ public final class CoverageModelEMComputeBlock {
          */
         cgbuilder
                 /* E[log(c_{st})] */
-                .addExternallyComputableNode(CoverageModelICGCacheNode.log_c_st.name())
+                .externallyComputableNode(CoverageModelICGCacheNode.log_c_st.name())
                 /* var[log(c_{st})] */
-                .addExternallyComputableNode(CoverageModelICGCacheNode.var_log_c_st.name())
+                .externallyComputableNode(CoverageModelICGCacheNode.var_log_c_st.name())
                 /* E[log(d_s)] */
-                .addExternallyComputableNode(CoverageModelICGCacheNode.log_d_s.name())
+                .externallyComputableNode(CoverageModelICGCacheNode.log_d_s.name())
                 /* var[log(d_s)] */
-                .addExternallyComputableNode(CoverageModelICGCacheNode.var_log_d_s.name())
+                .externallyComputableNode(CoverageModelICGCacheNode.var_log_d_s.name())
                 /* E[\gamma_s] */
-                .addExternallyComputableNode(CoverageModelICGCacheNode.gamma_s.name());
+                .externallyComputableNode(CoverageModelICGCacheNode.gamma_s.name());
 
         if (biasCovariatesEnabled) {
             cgbuilder
                     /* mean of bias covariates */
-                    .addExternallyComputableNode(CoverageModelICGCacheNode.W_tl.name())
+                    .externallyComputableNode(CoverageModelICGCacheNode.W_tl.name())
                     /* E[z_{sm}] */
-                    .addExternallyComputableNode(CoverageModelICGCacheNode.z_sl.name())
+                    .externallyComputableNode(CoverageModelICGCacheNode.z_sl.name())
                     /* E[z_{sm} z_{sn}] */
-                    .addExternallyComputableNode(CoverageModelICGCacheNode.zz_sll.name());
+                    .externallyComputableNode(CoverageModelICGCacheNode.zz_sll.name());
         }
 
         /*
@@ -242,7 +242,7 @@ public final class CoverageModelEMComputeBlock {
          */
         cgbuilder
                 /* log read counts */
-                .addComputableNode(CoverageModelICGCacheNode.log_n_st.name(),
+                .computableNode(CoverageModelICGCacheNode.log_n_st.name(),
                         new String[]{
                                 CoverageModelICGCacheTag.M_STEP_M.name(),
                                 CoverageModelICGCacheTag.E_STEP_D.name()},
@@ -251,26 +251,26 @@ public final class CoverageModelEMComputeBlock {
                                 CoverageModelICGCacheNode.M_st.name()},
                         calculate_log_n_st, true)
                 /* Poisson noise */
-                .addComputableNode(CoverageModelICGCacheNode.Sigma_st.name(),
+                .computableNode(CoverageModelICGCacheNode.Sigma_st.name(),
                         new String[]{},
                         new String[]{
                                 CoverageModelICGCacheNode.n_st.name(),
                                 CoverageModelICGCacheNode.M_st.name()},
                         calculate_Sigma_st, true)
                 /* \sum_s M_{st} */
-                .addComputableNode(CoverageModelICGCacheNode.sum_M_t.name(),
+                .computableNode(CoverageModelICGCacheNode.sum_M_t.name(),
                         new String[]{},
                         new String[]{CoverageModelICGCacheNode.M_st.name()},
                         calculate_sum_M_t, true)
                 /* \sum_t M_{st} */
-                .addComputableNode(CoverageModelICGCacheNode.sum_M_s.name(),
+                .computableNode(CoverageModelICGCacheNode.sum_M_s.name(),
                         new String[]{
                                 CoverageModelICGCacheTag.LOGLIKE_UNREG.name(),
                                 CoverageModelICGCacheTag.LOGLIKE_REG.name()},
                         new String[]{CoverageModelICGCacheNode.M_st.name()},
                         calculate_sum_M_s, true)
                 /* \Psi_{st} = \Psi_t + \Sigma_{st} + E[\gamma_s] */
-                .addComputableNode(CoverageModelICGCacheNode.tot_Psi_st.name(),
+                .computableNode(CoverageModelICGCacheNode.tot_Psi_st.name(),
                         new String[]{},
                         new String[]{
                                 CoverageModelICGCacheNode.Sigma_st.name(),
@@ -278,7 +278,7 @@ public final class CoverageModelEMComputeBlock {
                                 CoverageModelICGCacheNode.gamma_s.name()},
                         calculate_tot_Psi_st, true)
                 /* log(n_{st}) - E[log(c_{st})] - E[log(d_s)] - m_t */
-                .addComputableNode(CoverageModelICGCacheNode.Delta_st.name(),
+                .computableNode(CoverageModelICGCacheNode.Delta_st.name(),
                         new String[]{CoverageModelICGCacheTag.E_STEP_Z.name()},
                         new String[]{
                                 CoverageModelICGCacheNode.log_n_st.name(),
@@ -287,7 +287,7 @@ public final class CoverageModelEMComputeBlock {
                                 CoverageModelICGCacheNode.m_t.name()},
                         calculate_Delta_st, true)
                 /* \sum_{t} M_{st} \log(\Psi_{st}) */
-                .addComputableNode(CoverageModelICGCacheNode.loglike_normalization_s.name(),
+                .computableNode(CoverageModelICGCacheNode.loglike_normalization_s.name(),
                         new String[]{
                                 CoverageModelICGCacheTag.LOGLIKE_REG.name(),
                                 CoverageModelICGCacheTag.LOGLIKE_UNREG.name()},
@@ -297,7 +297,7 @@ public final class CoverageModelEMComputeBlock {
                                 CoverageModelICGCacheNode.log_n_st.name()},
                         calculate_loglike_normalization_s, true)
                 /* M_{st} \Psi_{st}^{-1} */
-                .addComputableNode(CoverageModelICGCacheNode.M_Psi_inv_st.name(),
+                .computableNode(CoverageModelICGCacheNode.M_Psi_inv_st.name(),
                         new String[]{
                                 CoverageModelICGCacheTag.E_STEP_W_UNREG.name(),
                                 CoverageModelICGCacheTag.E_STEP_W_REG.name(),
@@ -310,7 +310,7 @@ public final class CoverageModelEMComputeBlock {
                                 CoverageModelICGCacheNode.tot_Psi_st.name()},
                         calculate_M_Psi_inv_st, true)
                 /* log likelihood (w/o regularization) */
-                .addComputableNode(CoverageModelICGCacheNode.loglike_unreg.name(),
+                .computableNode(CoverageModelICGCacheNode.loglike_unreg.name(),
                         new String[]{CoverageModelICGCacheTag.LOGLIKE_UNREG.name()},
                         new String[]{
                                 CoverageModelICGCacheNode.B_st.name(),
@@ -322,7 +322,7 @@ public final class CoverageModelEMComputeBlock {
         if (biasCovariatesEnabled) {
             cgbuilder
                     /* E[W] E[z_s] */
-                    .addComputableNode(CoverageModelICGCacheNode.Wz_st.name(),
+                    .computableNode(CoverageModelICGCacheNode.Wz_st.name(),
                             new String[]{CoverageModelICGCacheTag.M_STEP_M.name(),
                                     CoverageModelICGCacheTag.E_STEP_D.name(),
                                     CoverageModelICGCacheTag.E_STEP_C.name()},
@@ -331,14 +331,14 @@ public final class CoverageModelEMComputeBlock {
                                     CoverageModelICGCacheNode.z_sl.name()},
                             calculate_Wz_st, true)
                     /* (E[z_s z_s^T] E[W W^T])_{tt} */
-                    .addComputableNode(CoverageModelICGCacheNode.WzzWT_st.name(),
+                    .computableNode(CoverageModelICGCacheNode.WzzWT_st.name(),
                             new String[]{},
                             new String[]{
                                     CoverageModelICGCacheNode.W_tl.name(),
                                     CoverageModelICGCacheNode.zz_sll.name()},
                             calculate_WzzWT_st, true)
                     /* v_{t\mu} */
-                    .addComputableNode(CoverageModelICGCacheNode.v_tl.name(),
+                    .computableNode(CoverageModelICGCacheNode.v_tl.name(),
                             new String[]{
                                     CoverageModelICGCacheTag.E_STEP_W_REG.name(),
                                     CoverageModelICGCacheTag.E_STEP_W_UNREG.name()},
@@ -348,7 +348,7 @@ public final class CoverageModelEMComputeBlock {
                                     CoverageModelICGCacheNode.z_sl.name()},
                             calculate_v_tl, false)
                     /* Q_{t\mu\nu} */
-                    .addComputableNode(CoverageModelICGCacheNode.Q_tll.name(),
+                    .computableNode(CoverageModelICGCacheNode.Q_tll.name(),
                             new String[]{
                                     CoverageModelICGCacheTag.E_STEP_W_REG.name(),
                                     CoverageModelICGCacheTag.E_STEP_W_UNREG.name()},
@@ -357,7 +357,7 @@ public final class CoverageModelEMComputeBlock {
                                     CoverageModelICGCacheNode.zz_sll.name()},
                             calculate_Q_tll, false)
                     /* B_{st} */
-                    .addComputableNode(CoverageModelICGCacheNode.B_st.name(),
+                    .computableNode(CoverageModelICGCacheNode.B_st.name(),
                             new String[]{
                                     CoverageModelICGCacheTag.M_STEP_PSI.name(),
                                     CoverageModelICGCacheTag.E_STEP_GAMMA.name()},
@@ -369,7 +369,7 @@ public final class CoverageModelEMComputeBlock {
                                     CoverageModelICGCacheNode.Wz_st.name()},
                             calculate_B_st_with_bias_covariates, true)
                     /* M_{st} . (log(n_{st}) - E[log(c_{st})] - E[log(d_s)]) - mean --- externally computed */
-                    .addComputableNode(CoverageModelICGCacheNode.Delta_PCA_st.name(),
+                    .computableNode(CoverageModelICGCacheNode.Delta_PCA_st.name(),
                             new String[]{},
                             new String[]{
                                     CoverageModelICGCacheNode.log_n_st.name(),
@@ -380,7 +380,7 @@ public final class CoverageModelEMComputeBlock {
         } else { /* no bias covariates */
             cgbuilder
                     /* B_{st} */
-                    .addComputableNode(CoverageModelICGCacheNode.B_st.name(),
+                    .computableNode(CoverageModelICGCacheNode.B_st.name(),
                             new String[]{
                                     CoverageModelICGCacheTag.M_STEP_PSI.name(),
                                     CoverageModelICGCacheTag.E_STEP_GAMMA.name()},
@@ -394,13 +394,13 @@ public final class CoverageModelEMComputeBlock {
         // TODO github/gatk-protected issue #701 -- this class is part of the upcoming CNV-avoiding regularizer
         //
         //            /* FFT[W] */
-        //            .addComputableNode(CoverageModelICGCacheNode.F_W_tl.name(),
+        //            .computableNode(CoverageModelICGCacheNode.F_W_tl.name(),
         //                   new String[]{},
         //                   new String[]{CoverageModelICGCacheNode.W_tl.name()},
         //                   null, true);
         //
         //            /* log likelihood (w/ regularization) */
-        //            .addComputableNode(CoverageModelICGCacheNode.loglike_reg.name(),
+        //            .computableNode(CoverageModelICGCacheNode.loglike_reg.name(),
         //                    new String[]{CoverageModelICGCacheTag.LOGLIKE_REG.name()},
         //                    new String[]{
         //                            CoverageModelICGCacheNode.B_st.name(),
@@ -411,7 +411,7 @@ public final class CoverageModelEMComputeBlock {
         //                            CoverageModelICGCacheNode.zz_sll.name()},
         //                    calculate_loglike_reg, true);
         //            /* \sum_t Q_{t\mu\nu} */
-        //            .addComputableNode(CoverageModelICGCacheNode.sum_Q_ll.name(),
+        //            .computableNode(CoverageModelICGCacheNode.sum_Q_ll.name(),
         //        new String[]{CoverageModelICGCacheTag.E_STEP_W_REG.name()},
         //        new String[]{CoverageModelICGCacheNode.Q_tll.name()},
         //        calculate_sum_Q_ll, true);
@@ -475,7 +475,7 @@ public final class CoverageModelEMComputeBlock {
      */
     @QueriesICG
     public INDArray getINDArrayFromCache(final CoverageModelICGCacheNode key) {
-        return ((DuplicableNDArray)icg.getValueWithRequiredEvaluations(key.name())).value();
+        return ((DuplicableNDArray)icg.fetchWithRequiredEvaluations(key.name())).value();
     }
 
     /**
@@ -488,7 +488,7 @@ public final class CoverageModelEMComputeBlock {
      */
     @QueriesICG
     public double getDoubleFromCache(final CoverageModelICGCacheNode key) {
-        return ((DuplicableNumber) icg.getValueWithRequiredEvaluations(key.name())).value().doubleValue();
+        return ((DuplicableNumber) icg.fetchWithRequiredEvaluations(key.name())).value().doubleValue();
     }
 
     private void assertBiasCovariatesEnabled() {
@@ -1162,13 +1162,8 @@ public final class CoverageModelEMComputeBlock {
      */
     public CoverageModelEMComputeBlock cloneWithUpdatedPrimitive(@Nonnull final CoverageModelICGCacheNode key,
                                                                  @Nullable final INDArray value) {
-        if (value == null) {
-            return new CoverageModelEMComputeBlock(targetBlock, numSamples, numLatents, ardEnabled,
-                    icg.nullifyNode(key.name()), latestMStepSignal);
-        } else {
-            return new CoverageModelEMComputeBlock(targetBlock, numSamples, numLatents, ardEnabled,
-                    icg.setValue(key.name(), new DuplicableNDArray(value)), latestMStepSignal);
-        }
+        return new CoverageModelEMComputeBlock(targetBlock, numSamples, numLatents, ardEnabled,
+                icg.setValue(key.name(), new DuplicableNDArray(value)), latestMStepSignal);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/CacheNode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/CacheNode.java
@@ -13,12 +13,20 @@ import java.util.Map;
  *
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
-public abstract class CacheNode {
-
+abstract class CacheNode {
+    /**
+     * A string identifier for the cache node
+     */
     private final String key;
 
+    /**
+     * The collection of string identifiers of the immediate parents of this node (can be empty)
+     */
     private final Collection<String> parents;
 
+    /**
+     * The collection of string identifiers of the tags associated to this node (can be empty)
+     */
     private final Collection<String> tags;
 
     /**
@@ -28,65 +36,104 @@ public abstract class CacheNode {
      * @param tags the tags associated to this cache node
      * @param parents immediate parents of this cache node
      */
-    public CacheNode(@Nonnull final String key,
-                     @Nonnull final Collection<String> tags,
-                     @Nonnull final Collection<String> parents) {
+    CacheNode(@Nonnull final String key,
+              @Nonnull final Collection<String> tags,
+              @Nonnull final Collection<String> parents) {
         this.key = Utils.nonNull(key, "The key of a cache node can not be null");
         this.tags = Collections.unmodifiableCollection(Utils.nonNull(tags, "The tag collection of a cache node can not be null"));
         this.parents = Collections.unmodifiableCollection(Utils.nonNull(parents, "The immediate parents of a cache node can not be null"));
     }
 
-    public abstract Duplicable get(@Nonnull final Map<String, Duplicable> dict);
+    /**
+     * Get the value stored in the node
+     *
+     * @param parents parent values (as a map from their string identifiers to their values)
+     * @return a {@link Duplicable}; possibly by reference
+     */
+    abstract Duplicable get(@Nonnull final Map<String, Duplicable> parents);
 
-    public abstract boolean isPrimitive();
+    /**
+     * Set the value of the node
+     *
+     * @param newValue new value; possibly stored by reference
+     * @throws UnsupportedOperationException if the node is automatically computable
+     */
+    abstract void set(@Nullable final Duplicable newValue) throws UnsupportedOperationException;
 
-    public abstract boolean isStoredValueAvailable();
+    /**
+     * Is the node primitive?
+     */
+    abstract boolean isPrimitive();
 
-    public abstract void set(@Nullable final Duplicable val);
+    /**
+     * Is the node initialized yet?
+     */
+    abstract boolean hasValue();
 
-    public abstract boolean isExternallyComputable();
+    /**
+     * Is the node externally computed?
+     */
+    abstract boolean isExternallyComputed();
 
-    public CacheNode duplicateWithUpdatedValue(final Duplicable newValue)
-            throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
-    }
+    /**
+     * Duplicate the node with updated value
+     *
+     * @param newValue new value; possibly stored by reference
+     * @return a new {@link CacheNode} with the same key, parents, and tags but with a new value
+     * @throws UnsupportedOperationException if the node is automatically computable
+     */
+    abstract CacheNode duplicateWithUpdatedValue(final Duplicable newValue) throws UnsupportedOperationException;
 
-    public CacheNode duplicate()
-            throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
-    }
+    /**
+     * Make a deep copy of the node
+     *
+     * @return a deeply copied instance of {@link CacheNode}
+     */
+    abstract CacheNode duplicate();
 
-    public String getKey() {
+    /**
+     * Get the string identifier of the node
+     * @return a non-null {@link String}
+     */
+    final String getKey() {
         return key;
     }
 
-    public Collection<String> getParents() {
-        return parents;
+    /**
+     * Get the collection of string identifier of the parents of this node (can be empty)
+     */
+    final Collection<String> getParents() {
+        return Collections.unmodifiableCollection(parents);
     }
 
-    public Collection<String> getTags() {
-        return tags;
+    /**
+     * Get the collection of string identifier of the tags associated to this node (can be empty)
+     */
+    final Collection<String> getTags() {
+        return Collections.unmodifiableCollection(tags);
     }
 
     @Override
-    public String toString() {
+    public final String toString() {
         return key;
     }
 
+    /**
+     * NOTE: equality comparison is done just based on the key
+     * @param other another object
+     */
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        CacheNode cacheNode = (CacheNode) o;
-
-        if (!key.equals(cacheNode.key)) return false;
-        if (!parents.equals(cacheNode.parents)) return false;
-        return tags.equals(cacheNode.tags);
+    public final boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        return (key.equals(((CacheNode) other).key));
     }
 
+    /**
+     * NOTE: hashcode is generated just based on the key
+     */
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return key.hashCode();
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ComputableGraphStructure.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ComputableGraphStructure.java
@@ -1,292 +1,379 @@
 package org.broadinstitute.hellbender.tools.coveragemodel.cachemanager;
 
+import avro.shaded.com.google.common.collect.Sets;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * This class pre-computes a number of useful auxiliary properties for the DAG specified by
- * a set of {@link CacheNode}s. These include:
+ * This class performs consistency checks and computes several structural properties for the DAG specified by a
+ * set of {@link CacheNode}s. These include:
  *
- * - topological order for evaluating a computable node,
- * - topological order for mutating a primitive/externally-computed node, and
- * - topological order for evaluating all nodes associated to a tag (see {@link ImmutableComputableGraph}).
+ * - assertion for existence of no cycles
+ * - construction of maps of nodes to their descendants and ancestors
+ * - propagation of tags from descendants to ancestors
+ * - topological order for evaluating a computable node
+ * - topological order for mutating a primitive/externally-computed node and updating the caches of all involved nodes
+ * - topological order for evaluating all nodes associated to a tag (see {@link ImmutableComputableGraph})
+ * - topological order for complete computation of the graph
  *
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
-public final class ComputableGraphStructure implements Serializable {
+final class ComputableGraphStructure implements Serializable {
 
     private static final long serialVersionUID = -3124293279477371159L;
 
     private final Set<String> nodeKeysSet;
     private final Set<String> nodeTagsSet;
-    private final Map<String, Set<String>> allTagsMap;
-    private final Map<String, Set<String>> immediateDescendentsMap;
-    private final Map<String, Set<String>> immediateParentsMap;
-    private final Map<String, Set<String>> allDescendentsMap;
-    private final Map<String, Set<String>> allParentsMap;
-    private final Map<String, Integer> depthsMap;
-    private final Map<Integer, Set<String>> nodesByDepthMap;
-    private final Map<String, Set<String>> nodesByTagMap;
+    private final Map<String, Set<String>> inducedTagsMap;
+    private final Map<String, Set<String>> descendantsMap;
+    private final Map<String, Set<String>> childrenMap;
+    private final Map<String, Set<String>> parentsMap;
+    private final Map<String, Set<String>> ancestorsMap;
+    private final Map<String, Integer> topologicalOrderMap;
     private final Map<String, List<String>> topologicalOrderForNodeEvaluation;
     private final Map<String, List<String>> topologicalOrderForNodeMutation;
     private final Map<String, List<String>> topologicalOrderForTagEvaluation;
     private final List<String> topologicalOrderForCompleteEvaluation;
 
     /**
+     * An arbitrary negative number to denote the to-be-determined topological order a node
+     */
+    private static final int UNDEFINED_TOPOLOGICAL_ORDER = -1;
+
+    /**
      * Package-private constructor from a set of {@link CacheNode}s. The graph is specified by the immediate
-     * parents and descendents of each node. A {@link CyclicGraphException} is thrown of the graph has a cycle.
+     * parents and descendants of each node. A {@link CyclicGraphException} is thrown of the graph has a cycle.
      *
      * @param nodeSet a set of {@link CacheNode}s
      */
     ComputableGraphStructure(@Nonnull final Set<CacheNode> nodeSet) {
-        /* create maps for descendents, parents, and tags */
-        nodeKeysSet = nodeSet.stream().map(CacheNode::getKey).collect(Collectors.toSet());
-        immediateDescendentsMap = new HashMap<>();
-        immediateParentsMap = new HashMap<>();
-        final Map<String, Set<String>> initialTagsMap = new HashMap<>();
-        nodeKeysSet.forEach(key -> {
-            immediateDescendentsMap.put(key, new HashSet<>());
-            immediateParentsMap.put(key, new HashSet<>());
-            initialTagsMap.put(key, new HashSet<>());
-        });
 
-        /* immediate parents, descendents and tags */
-        nodeSet.forEach(node -> {
-            final String nodeKey = node.getKey();
-            node.getParents().forEach(parent -> immediateDescendentsMap.get(parent).add(nodeKey));
-            immediateParentsMap.get(nodeKey).addAll(node.getParents());
-            initialTagsMap.get(nodeKey).addAll(node.getTags());
-        });
+        /* create the set of keys */
+        Utils.nonNull(nodeSet, "The given set of nodes must be non-null");
+        nodeKeysSet = extractKeys(nodeSet);
+        nodeTagsSet = extractTags(nodeSet);
+        assertParentKeysExist(nodeSet, nodeKeysSet);
 
-        /* check the descendents and parents */
-        for (final String node : nodeKeysSet) {
-            Utils.validateArg(nodeKeysSet.containsAll(immediateDescendentsMap.get(node)), "The immediate descendents" +
-                    " node map refers to unknown nodes.");
-            Utils.validateArg(nodeKeysSet.containsAll(immediateParentsMap.get(node)), "The immediate parents node map" +
-                    " refers to unknown nodes.");
-        }
+        /* nodeKey -> set of parents' keys */
+        parentsMap = getParentsMap(nodeSet);
 
-        /* create maps for descendents, parents, and depthsMap */
-        allDescendentsMap = new HashMap<>();
-        allParentsMap = new HashMap<>();
-        depthsMap = new HashMap<>();
-        allTagsMap = new HashMap<>();
-        nodeKeysSet.forEach(key -> {
-            allDescendentsMap.put(key, new HashSet<>());
-            allParentsMap.put(key, new HashSet<>());
-            allTagsMap.put(key, new HashSet<>());
-            depthsMap.put(key, null);
-        });
+        /* nodeKey -> set of children's keys */
+        childrenMap = getChildrenMap(nodeSet);
 
-        /* calculate the depth of each node; primitive nodes or nodes with no immediateParentsMap have depth 0 */
-        immediateParentsMap.keySet().stream()
-                .filter(node -> immediateParentsMap.get(node).size() == 0)
-                .forEach(rootNodeKey -> depthsMap.replace(rootNodeKey, 0));
-        nodeKeysSet.forEach(this::updateDepth);
+        /* nodeKey -> topological order */
+        topologicalOrderMap = getTopologicalOrderMap(parentsMap, nodeKeysSet);
 
-        final int maxDepth = Collections.max(depthsMap.values());
+        /* topological order -> set of node keys */
+        final Map<Integer, Set<String>> nodesByTopologicalOrderMap = getNodesByTopologicalOrderMap(topologicalOrderMap,
+                nodeKeysSet);
 
-        /* list of nodes by their depthsMap */
-        nodesByDepthMap = new HashMap<>();
-        IntStream.range(0, maxDepth + 1).forEach(depth -> nodesByDepthMap.put(depth,
-                nodeKeysSet.stream().filter(node -> depthsMap.get(node) == depth).collect(Collectors.toSet())));
+        /* nodeKey -> set of descendants' keys */
+        descendantsMap = getDescendantsMap(childrenMap, nodesByTopologicalOrderMap);
 
-        /* all descendents of the deepest nodes (empty set) */
-        nodesByDepthMap.get(maxDepth).forEach(node -> allDescendentsMap.put(node, new HashSet<>()));
-        /* get all descendents by descending the tree */
-        for (int depth = maxDepth - 1; depth >= 0; depth -= 1) {
-            for (final String node : nodesByDepthMap.get(depth)) {
-                final Set<String> nodeAllDescendents = new HashSet<>();
-                nodeAllDescendents.addAll(immediateDescendentsMap.get(node));
-                for (final String child : immediateDescendentsMap.get(node)) {
-                    nodeAllDescendents.addAll(allDescendentsMap.get(child));
-                }
-                allDescendentsMap.put(node, nodeAllDescendents);
-            }
-        }
+        /* nodeKey -> set of ancestors' keys */
+        ancestorsMap = getAncestorsMap(parentsMap, nodesByTopologicalOrderMap);
 
-        /* all parents of the primitive nodes (empty set) */
-        nodesByDepthMap.get(0).forEach(node -> allParentsMap.put(node, new HashSet<>()));
-        for (int depth = 1; depth <= maxDepth; depth += 1) {
-            for (final String node : nodesByDepthMap.get(depth)) {
-                final Set<String> nodeAllParents = new HashSet<>();
-                nodeAllParents.addAll(immediateParentsMap.get(node));
-                for (final String parent : immediateParentsMap.get(node)) {
-                    nodeAllParents.addAll(allParentsMap.get(parent));
-                }
-                allParentsMap.put(node, nodeAllParents);
-            }
-        }
+        /* nodeKey -> set of upward-propagated tags */
+        inducedTagsMap = getInducedTagsMap(nodeSet, nodesByTopologicalOrderMap, ancestorsMap);
 
-        /* build the full tags map; the parents inherit the tags of the descendents */
-        nodesByDepthMap.get(maxDepth).forEach(node -> allTagsMap.get(node).addAll(initialTagsMap.get(node)));
-        for (int depth = maxDepth - 1; depth >= 0; depth -= 1) {
-            nodesByDepthMap.get(depth).forEach(node -> {
-                allTagsMap.get(node).addAll(initialTagsMap.get(node));
-                immediateDescendentsMap.get(node).forEach(desc -> allTagsMap.get(node).addAll(initialTagsMap.get(desc)));
-            });
-        }
-
-        /* build a nodes-by-tag map and nodeTagsSet */
-        nodeTagsSet = initialTagsMap.values().stream().flatMap(Set::stream).collect(Collectors.toSet());
-        nodesByTagMap = new HashMap<>();
-        nodeTagsSet.forEach(tag ->
-                nodesByTagMap.put(tag, new HashSet<>()));
-        nodeKeysSet.forEach(node ->
-                allTagsMap.get(node).forEach(tag ->
-                        nodesByTagMap.get(tag).add(node)));
+        /* tag -> set of tagged nodes, including upward-propagation */
+        final Map<String, Set<String>> nodesByInducedTagMap = getNodesByInducedTagMap(inducedTagsMap, nodeKeysSet,
+                nodeTagsSet);
 
         /* topological order for evaluating a single node */
-        topologicalOrderForNodeEvaluation = new HashMap<>();
-        for (final String node : nodeKeysSet) {
-            final List<String> allParentsIncludingTheNode = new ArrayList<>();
-            allParentsIncludingTheNode.addAll(allParentsMap.get(node));
-            allParentsIncludingTheNode.add(node);
-            /* sort by depth */
-            allParentsIncludingTheNode.sort(Comparator.comparingInt(depthsMap::get));
-            topologicalOrderForNodeEvaluation.put(node, allParentsIncludingTheNode);
-        }
+        topologicalOrderForNodeEvaluation = getTopologicalOrderForNodeEvaluation(nodeKeysSet, topologicalOrderMap,
+                ancestorsMap);
 
         /* topological order for evaluating all nodes associated to a tag */
-        topologicalOrderForTagEvaluation = new HashMap<>();
-        for (final String tag : nodeTagsSet) {
-            final Set<String> allParentsIncludingTheNodesSet = new HashSet<>();
-            for (final String node : nodesByTagMap.get(tag)) {
-                allParentsIncludingTheNodesSet.addAll(allParentsMap.get(node));
-                allParentsIncludingTheNodesSet.add(node);
-            }
-            final List<String> allParentsIncludingTheNodesList = new ArrayList<>();
-            allParentsIncludingTheNodesList.addAll(allParentsIncludingTheNodesSet);
-            /* sort by depth */
-            allParentsIncludingTheNodesList.sort(Comparator.comparingInt(depthsMap::get));
-            topologicalOrderForTagEvaluation.put(tag, allParentsIncludingTheNodesList);
-        }
+        topologicalOrderForTagEvaluation = getTopologicalOrderForTagEvaluation(nodeTagsSet, topologicalOrderMap,
+                nodesByInducedTagMap, ancestorsMap);
 
         /* topological order for evaluating all nodes */
-        topologicalOrderForCompleteEvaluation = new ArrayList<>();
-        topologicalOrderForCompleteEvaluation.addAll(nodeKeysSet);
-        topologicalOrderForCompleteEvaluation.sort(Comparator.comparingInt(depthsMap::get));
+        topologicalOrderForCompleteEvaluation = getTopologicalOrderForCompleteEvaluation(nodeKeysSet,
+                topologicalOrderMap);
 
-        /* topological order for updating the descendents of a mutated node */
-        topologicalOrderForNodeMutation = new HashMap<>();
-        for (final String mutNode : nodeKeysSet) {
-            final Set<String> allInvolvedSet = new HashSet<>();
-            allInvolvedSet.add(mutNode);
-            for (final String desc : allDescendentsMap.get(mutNode)) {
-                allInvolvedSet.add(desc);
-                allInvolvedSet.addAll(allParentsMap.get(desc));
+        /* topological order for updating the descendants of a mutated node */
+        topologicalOrderForNodeMutation = getTopologicalOrderForNodeMutation(nodeKeysSet, ancestorsMap,
+                descendantsMap, topologicalOrderMap);
+    }
+
+    private static void assertParentKeysExist(@Nonnull final Set<CacheNode> nodeSet,
+                                              @Nonnull final Set<String> nodeKeysSet) {
+        for (final CacheNode node : nodeSet) {
+            if (!nodeKeysSet.containsAll(node.getParents())) {
+                final Set<String> undefinedParents = Sets.difference(new HashSet<>(node.getParents()), nodeKeysSet);
+                throw new NonexistentParentNodeKey("Node " + ImmutableComputableGraphUtils.quote(node.getKey()) +
+                        " depends on undefined parent(s): " + undefinedParents.stream()
+                        .map(ImmutableComputableGraphUtils::quote).collect(Collectors.joining(", ")));
             }
-            final List<String> allInvolvedList = new ArrayList<>();
-            allInvolvedList.addAll(allInvolvedSet);
-            /* sort by depth */
-            allInvolvedList.sort(Comparator.comparingInt(depthsMap::get));
-            topologicalOrderForNodeMutation.put(mutNode, allInvolvedList);
         }
+    }
+
+    private static Set<String> extractTags(@Nonnull Set<CacheNode> nodeSet) {
+        return nodeSet.stream().map(CacheNode::getTags).flatMap(Collection::stream).collect(Collectors.toSet());
+    }
+
+    private static Set<String> extractKeys(@Nonnull Set<CacheNode> nodeSet) {
+        return nodeSet.stream().map(CacheNode::getKey).collect(Collectors.toSet());
+    }
+
+    private static Map<String, Integer> getTopologicalOrderMap(@Nonnull final Map<String,Set<String>> immediateParentsMap,
+                                                               @Nonnull final Set<String> nodeKeysSet) {
+        final Map<String, Integer> topologicalOrderMap = new HashMap<>();
+        nodeKeysSet.forEach(key -> topologicalOrderMap.put(key, UNDEFINED_TOPOLOGICAL_ORDER));
+        nodeKeysSet.forEach(nodeKey -> updateDepth(nodeKey, 0, nodeKeysSet, immediateParentsMap, topologicalOrderMap));
+        return topologicalOrderMap;
+    }
+
+    private static Map<Integer, Set<String>> getNodesByTopologicalOrderMap(Map<String, Integer> topologicalOrderMap,
+                                                                          Set<String> nodeKeysSet) {
+        final int maxDepth = Collections.max(topologicalOrderMap.values());
+        final Map<Integer, Set<String>> nodesByTopologicalOrderMap = new HashMap<>();
+        IntStream.range(0, maxDepth + 1).forEach(depth ->
+                nodesByTopologicalOrderMap.put(depth,
+                        nodeKeysSet.stream().filter(node ->
+                                topologicalOrderMap.get(node) == depth).collect(Collectors.toSet())));
+        return nodesByTopologicalOrderMap;
+    }
+
+    private static Map<String, Set<String>> getParentsMap(@Nonnull final Set<CacheNode> nodeSet) {
+        return nodeSet.stream()
+                .collect(Collectors.toMap(CacheNode::getKey, node -> new HashSet<>(node.getParents())));
+    }
+
+    private static Map<String, Set<String>> getChildrenMap(@Nonnull final Set<CacheNode> nodeSet) {
+        final Map<String, Set<String>> childrenMap = nodeSet.stream()
+                .collect(Collectors.toMap(CacheNode::getKey, node -> new HashSet<String>()));
+        nodeSet.forEach(node -> node.getParents().forEach(parentKey -> childrenMap.get(parentKey)
+                .add(node.getKey())));
+        return childrenMap;
+    }
+
+    private static Map<String, Set<String>> getInducedTagsMap(@Nonnull final Set<CacheNode> nodeSet,
+                                                              @Nonnull final Map<Integer, Set<String>> nodesByTopologicalOrderMap,
+                                                              @Nonnull final Map<String, Set<String>> allParentsMap) {
+        final int maxDepth = Collections.max(nodesByTopologicalOrderMap.keySet());
+        /* initialize with given tags */
+        final Map<String, Set<String>> allTagsMap = nodeSet.stream()
+                .collect(Collectors.toMap(CacheNode::getKey, node -> new HashSet<>(node.getTags())));
+        /* propagate tags to all parents */
+        for (int depth = maxDepth; depth >= 0; depth--) {
+            nodesByTopologicalOrderMap.get(depth)
+                    .forEach(nodeKey -> allParentsMap.get(nodeKey)
+                            .forEach(parentKey -> allTagsMap.get(parentKey).addAll(allTagsMap.get(nodeKey))));
+        }
+        return allTagsMap;
+    }
+
+    private static Map<String, Set<String>> getNodesByInducedTagMap(@Nonnull final Map<String, Set<String>> allTagsMap,
+                                                                    @Nonnull final Set<String> nodeKeysSet,
+                                                                    @Nonnull final Set<String> nodeTagsSet) {
+        final Map<String, Set<String>> nodesByTagMap = nodeTagsSet.stream()
+                .collect(Collectors.toMap(Function.identity(), tag -> new HashSet<String>()));
+        nodeKeysSet.forEach(nodeKey ->
+                allTagsMap.get(nodeKey).forEach(tag ->
+                        nodesByTagMap.get(tag).add(nodeKey)));
+        return nodesByTagMap;
+    }
+
+    private static Map<String, Set<String>> getDescendantsMap(@Nonnull final Map<String, Set<String>> childrenMap,
+                                                              @Nonnull final Map<Integer, Set<String>> nodesByTopologicalOrderMap) {
+        final Map<String, Set<String>> descendantsMap = new HashMap<>();
+        final int maxDepth = Collections.max(nodesByTopologicalOrderMap.keySet());
+        /* deepest nodes have no descendants */
+        nodesByTopologicalOrderMap.get(maxDepth).forEach(node -> descendantsMap.put(node, new HashSet<>()));
+        /* get all descendants by ascending the tree */
+        for (int depth = maxDepth - 1; depth >= 0; depth -= 1) {
+            for (final String node : nodesByTopologicalOrderMap.get(depth)) {
+                final Set<String> nodeDescendants = new HashSet<>();
+                nodeDescendants.addAll(childrenMap.get(node));
+                for (final String child : childrenMap.get(node)) {
+                    nodeDescendants.addAll(descendantsMap.get(child));
+                }
+                descendantsMap.put(node, nodeDescendants);
+            }
+        }
+        return descendantsMap;
+    }
+
+    private static Map<String, Set<String>> getAncestorsMap(@Nonnull final Map<String, Set<String>> parentsMap,
+                                                            @Nonnull final Map<Integer, Set<String>> nodesByTopologicalOrderMap) {
+        final Map<String, Set<String>> ancestorsMap = new HashMap<>();
+        final int maxDepth = Collections.max(nodesByTopologicalOrderMap.keySet());
+        nodesByTopologicalOrderMap.get(0).forEach(node -> ancestorsMap.put(node, new HashSet<>()));
+        for (int depth = 1; depth <= maxDepth; depth += 1) {
+            for (final String node : nodesByTopologicalOrderMap.get(depth)) {
+                final Set<String> nodeAncestors = new HashSet<>();
+                nodeAncestors.addAll(parentsMap.get(node));
+                for (final String parent : parentsMap.get(node)) {
+                    nodeAncestors.addAll(ancestorsMap.get(parent));
+                }
+                ancestorsMap.put(node, nodeAncestors);
+            }
+        }
+        return ancestorsMap;
+    }
+
+    private static Map<String, List<String>> getTopologicalOrderForNodeEvaluation(@Nonnull final Set<String> nodeKeysSet,
+                                                                                  @Nonnull final Map<String, Integer> topologicalOrderMap,
+                                                                                  @Nonnull final Map<String, Set<String>> ancestorsMap) {
+        final Map<String, List<String>> topologicalOrderForNodeEvaluation = new HashMap<>();
+        for (final String nodeKey : nodeKeysSet) {
+            final List<String> allParentsIncludingTheNode = new ArrayList<>();
+            allParentsIncludingTheNode.addAll(ancestorsMap.get(nodeKey));
+            allParentsIncludingTheNode.add(nodeKey);
+            /* sort by depth */
+            allParentsIncludingTheNode.sort(Comparator.comparingInt(topologicalOrderMap::get));
+            topologicalOrderForNodeEvaluation.put(nodeKey, allParentsIncludingTheNode);
+        }
+        return topologicalOrderForNodeEvaluation;
+    }
+
+    private static Map<String, List<String>> getTopologicalOrderForTagEvaluation(@Nonnull final Set<String> nodeTagsSet,
+                                                                                 @Nonnull final Map<String, Integer> topologicalOrderMap,
+                                                                                 @Nonnull final Map<String, Set<String>> nodesByTagMap,
+                                                                                 @Nonnull final Map<String, Set<String>> ancestorsMap) {
+        final Map<String, List<String>> topologicalOrderForTagEvaluation = new HashMap<>();
+        for (final String tag : nodeTagsSet) {
+            final Set<String> ancestorsIncludingTheTaggedNodesSet = new HashSet<>();
+            for (final String node : nodesByTagMap.get(tag)) {
+                ancestorsIncludingTheTaggedNodesSet.addAll(ancestorsMap.get(node));
+                ancestorsIncludingTheTaggedNodesSet.add(node);
+            }
+            final List<String> ancestorsIncludingTheTaggedNodesList = new ArrayList<>();
+            ancestorsIncludingTheTaggedNodesList.addAll(ancestorsIncludingTheTaggedNodesSet);
+            /* sort by depth */
+            ancestorsIncludingTheTaggedNodesList.sort(Comparator.comparingInt(topologicalOrderMap::get));
+            topologicalOrderForTagEvaluation.put(tag, ancestorsIncludingTheTaggedNodesList);
+        }
+        return topologicalOrderForTagEvaluation;
+    }
+
+    private static List<String> getTopologicalOrderForCompleteEvaluation(@Nonnull final Set<String> nodeKeysSet,
+                                                                         @Nonnull final Map<String, Integer> topologicalOrderMap) {
+        return new ArrayList<>(nodeKeysSet).stream()
+                .sorted(Comparator.comparingInt(topologicalOrderMap::get))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Topological order for mutating a primitive/externally-computed node and updating the caches of the
+     * involved nodes. These include mutated node, its descendants, and the ancestors of all of its descendants.
+     * The latter is required for updating the caches of the descendants.
+     */
+    private static Map<String, List<String>> getTopologicalOrderForNodeMutation(@Nonnull final Set<String> nodeKeysSet,
+                                                                                @Nonnull final Map<String, Set<String>> ancestorsMap,
+                                                                                @Nonnull final Map<String, Set<String>> descendantsMap,
+                                                                                @Nonnull final Map<String, Integer> topologicalOrderMap) {
+        final Map<String, List<String>> topologicalOrderForNodeMutation = new HashMap<>();
+        for (final String nodeKey : nodeKeysSet) {
+            final Set<String> allInvolvedNodesSet = new HashSet<>();
+            allInvolvedNodesSet.add(nodeKey);
+            allInvolvedNodesSet.addAll(descendantsMap.get(nodeKey));
+            for (final String descendantNodeKey : descendantsMap.get(nodeKey)) {
+                allInvolvedNodesSet.add(descendantNodeKey);
+                allInvolvedNodesSet.addAll(ancestorsMap.get(descendantNodeKey));
+            }
+            final List<String> allInvolvedNodesList = new ArrayList<>();
+            allInvolvedNodesList.addAll(allInvolvedNodesSet);
+            allInvolvedNodesList.sort(Comparator.comparingInt(topologicalOrderMap::get));
+            topologicalOrderForNodeMutation.put(nodeKey, allInvolvedNodesList);
+        }
+        return topologicalOrderForNodeMutation;
     }
 
     /**
      * Updates the depth of a node recursively
-     *
-     * @param nodeKey the key of the node to update
-     */
-    private void updateDepth(final String nodeKey) {
-        if (depthsMap.get(nodeKey) == null) {
-            immediateParentsMap.get(nodeKey).forEach(this::updateDepth);
-            final int depth = Collections.max(immediateParentsMap.get(nodeKey).stream().map(depthsMap::get)
-                    .collect(Collectors.toList())) + 1;
-            if (depth > nodeKeysSet.size() - 1) {
-                throw new CyclicGraphException("The graph has cycles");
-            }
-            depthsMap.replace(nodeKey, depth);
+     * */
+    private static void updateDepth(@Nonnull final String nodeKey, final int recursion,
+                                    @Nonnull Set<String> nodeKeysSet,
+                                    @Nonnull Map<String, Set<String>> parentsMap,
+                                    @Nonnull Map<String, Integer> topologicalOrderMap) {
+        if (recursion > nodeKeysSet.size()) {
+            throw new CyclicGraphException("The graph is not acyclic");
         }
+        if (parentsMap.get(nodeKey).isEmpty()) {
+            topologicalOrderMap.put(nodeKey, 0);
+        } else if (topologicalOrderMap.get(nodeKey) == UNDEFINED_TOPOLOGICAL_ORDER) {
+            parentsMap.get(nodeKey).forEach(parentNodeKey -> updateDepth(parentNodeKey,
+                    recursion + 1, nodeKeysSet, parentsMap, topologicalOrderMap));
+            final int maxParentDepth = parentsMap.get(nodeKey).stream()
+                    .map(topologicalOrderMap::get)
+                    .max(Integer::compareTo)
+                    .get(); /* guaranteed to have a value */
+            topologicalOrderMap.put(nodeKey, maxParentDepth + 1);
+        }
+        /* do nothing otherwise -- we already have the order for this node */
     }
 
-    public Set<String> getNodeKeysSet() { return nodeKeysSet; }
+    Set<String> getNodeKeysSet() { return nodeKeysSet; }
 
-    public Set<String> getNodeTagsSet() { return nodeTagsSet; }
+    Set<String> getNodeTagsSet() { return nodeTagsSet; }
 
-    public Set<String> getAllDescendents(@Nonnull final String nodeKey) {
-        return allDescendentsMap.get(nodeKey);
+    Set<String> getInducedTagsForNode(final String nodeKey) {
+        return inducedTagsMap.get(nodeKey);
     }
 
-    public List<String> getTopologicalOrderForNodeEvaluation(final String nodeKey) {
+    int getTopologicalOrder(@Nonnull final String nodeKey) {
+        return topologicalOrderMap.get(nodeKey);
+    }
+
+    Set<String> getChildren(@Nonnull final String nodeKey) {
+        return childrenMap.get(nodeKey);
+    }
+
+    Set<String> getParents(@Nonnull final String nodeKey) {
+        return parentsMap.get(nodeKey);
+    }
+
+    Set<String> getAncestors(@Nonnull final String nodeKey) {
+        return ancestorsMap.get(nodeKey);
+    }
+
+    Set<String> getDescendants(@Nonnull final String nodeKey) {
+        return descendantsMap.get(nodeKey);
+    }
+
+    List<String> getTopologicalOrderForNodeEvaluation(final String nodeKey) {
         return topologicalOrderForNodeEvaluation.get(nodeKey);
     }
 
-    public List<String> getTopologicalOrderForNodeMutation(final String nodeKey) {
+    List<String> getTopologicalOrderForNodeMutation(final String nodeKey) {
         return topologicalOrderForNodeMutation.get(nodeKey);
     }
 
-    public List<String> getTopologicalOrderForTagEvaluation(final String tagKey) {
+    List<String> getTopologicalOrderForTagEvaluation(final String tagKey) {
         return topologicalOrderForTagEvaluation.get(tagKey);
     }
 
-    public List<String> getTopologicalOrderForCompleteEvaluation() {
+    List<String> getTopologicalOrderForCompleteEvaluation() {
         return topologicalOrderForCompleteEvaluation;
-    }
-
-    @Override
-    public String toString() {
-        String status = "";
-        for (final String nodeKey : nodeKeysSet) {
-            status += "node: " + nodeKey + "\n" +
-                    "\tdepth: " + depthsMap.get(nodeKey) + "\n" +
-                    "\timmediate parents: " +
-                    immediateParentsMap.get(nodeKey).stream().collect(Collectors.joining(", ", "[", "]\n")) +
-                    "\timmediate descendents: " +
-                    immediateDescendentsMap.get(nodeKey).stream().collect(Collectors.joining(", ", "[", "]\n")) +
-                    "\tall parents: " +
-                    allParentsMap.get(nodeKey).stream().collect(Collectors.joining(", ", "[", "]\n")) +
-                    "\tall descendents: " +
-                    allDescendentsMap.get(nodeKey).stream().collect(Collectors.joining(", ", "[", "]\n")) +
-                    "\tall tags: " +
-                    allTagsMap.get(nodeKey).stream().collect(Collectors.joining(", ", "[", "]\n"));
-        }
-
-        status += "\n";
-        for (final String tag : nodeTagsSet) {
-            status += "tag: " + tag + ", nodes: " +
-                    nodesByTagMap.get(tag).stream().collect(Collectors.joining(", ", "[", "]\n"));
-        }
-
-        status += "\n";
-        for (final String tag : nodeTagsSet) {
-            status += "topological order for evaluating tag: " + tag + ", nodes:" +
-                    topologicalOrderForTagEvaluation.get(tag).stream().
-                            map(nodeKey -> nodeKey + "(" + depthsMap.get(nodeKey) + ")").
-                            collect(Collectors.joining(", ", "[", "]\n"));
-        }
-
-        status += "\n";
-        for (final String node : nodeKeysSet) {
-            status += "topological order evaluating node: " + node + ", nodes: " +
-                    topologicalOrderForNodeEvaluation.get(node).stream().
-                            map(nodeKey -> nodeKey + "(" + depthsMap.get(nodeKey) + ")").
-                            collect(Collectors.joining(", ", "[", "]\n"));
-        }
-
-        status += "\n";
-        for (final String node : nodesByDepthMap.get(0)) {
-            status += "topological order for node mutation: " + node + ", nodes: " +
-                    topologicalOrderForNodeMutation.get(node).stream().
-                            map(nodeKey -> nodeKey + "(" + depthsMap.get(nodeKey) + ")").
-                            collect(Collectors.joining(", ", "[", "]\n"));
-        }
-        return status;
     }
 
     /**
      * This exception will be thrown if the graph has loops
      */
-    public final class CyclicGraphException extends RuntimeException {
+    static final class CyclicGraphException extends RuntimeException {
         private static final long serialVersionUID = 5887360871425098163L;
 
-        public CyclicGraphException(String s) {
+        CyclicGraphException(String s) {
+            super(s);
+        }
+    }
+
+    /**
+     * This exception will be thrown if an alleged parent node key is missing
+     */
+    static final class NonexistentParentNodeKey extends RuntimeException {
+        private static final long serialVersionUID = 586676245552229897L;
+
+        NonexistentParentNodeKey(String s) {
             super(s);
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ComputableNodeFunction.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ComputableNodeFunction.java
@@ -37,11 +37,23 @@ public interface ComputableNodeFunction {
      * @param key parent key
      * @param parents parent key-value map
      * @throws ParentValueNotFoundException if the parent key is not in the map
-     * @return
      */
     default INDArray fetchINDArray(final String key, final Map<String, Duplicable> parents)
             throws ParentValueNotFoundException, ClassCastException {
         return ((DuplicableNDArray)fetch(key, parents)).value();
+    }
+
+    /**
+     * Fetches a parent node value from a given map and casts it to a double
+     *
+     * @param key parent key
+     * @param parents parent key-value map
+     * @throws ParentValueNotFoundException if the parent key is not in the map
+     */
+    @SuppressWarnings("unchecked")
+    default double fetchDouble(final String key, final Map<String, Duplicable> parents)
+            throws ParentValueNotFoundException, ClassCastException {
+        return ((DuplicableNumber<Double>)fetch(key, parents)).value();
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/Duplicable.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/Duplicable.java
@@ -27,4 +27,9 @@ public interface Duplicable {
      * @return boolean
      */
     boolean hasValue();
+
+    /**
+     * Returns the stored value
+     */
+    Object value();
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/DuplicableNDArray.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/DuplicableNDArray.java
@@ -30,22 +30,12 @@ public class DuplicableNDArray implements Duplicable {
 
     @Override
     public boolean hasValue() {
-        return value == null;
+        return value != null;
     }
 
+    @Override
     public INDArray value() {
         return value;
-    }
-
-    public static INDArray of(final Duplicable obj) {
-        if (obj == null) {
-            throw new NullPointerException("The input duplicable object is null.");
-        }
-        if (obj instanceof DuplicableNDArray) {
-            return ((DuplicableNDArray)obj).value();
-        } else {
-            throw new ClassCastException("Can not cast " + obj + " to an INDArray.");
-        }
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/DuplicableNumber.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/DuplicableNumber.java
@@ -24,19 +24,12 @@ public class DuplicableNumber<NUMBER extends Number> implements Duplicable {
 
     @Override
     public boolean hasValue() {
-        return value == null;
+        return value != null;
     }
 
+    @Override
     public NUMBER value() {
         return value;
-    }
-
-    public static double of(final Duplicable obj) {
-        if (obj instanceof DuplicableNumber) {
-            return ((DuplicableNumber)obj).value().doubleValue();
-        } else {
-            throw new ClassCastException("Can not cast " + obj + " to a number.");
-        }
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ImmutableComputableGraph.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ImmutableComputableGraph.java
@@ -1,34 +1,35 @@
 package org.broadinstitute.hellbender.tools.coveragemodel.cachemanager;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
+import com.google.common.annotations.VisibleForTesting;
+import org.broadinstitute.hellbender.tools.coveragemodel.cachemanager.ImmutableComputableGraphUtils.ImmutableComputableGraphBuilder;
 import org.broadinstitute.hellbender.utils.Utils;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.Serializable;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * This class provides a general purpose framework for evaluating functions on directed acyclic graphs consisting of
+ * This class provides a general purpose framework for evaluating functions on directed acyclic graphs (DAG) consisting of
  * "primitive" and "computable" nodes. Primitive nodes {@link PrimitiveCacheNode} are value placeholders while computable
  * nodes {@link ComputableCacheNode} evaluate a function on the graph. Importantly, computable nodes may cache their
- * evaluations to avoid redundant expensive computations.
+ * values in order to avoid redundant/expensive computations. This class implements automatic bookkeeping strategies
+ * for caching the values of computable nodes and updating the status of the cached values after mutating the primitive nodes.
  *
- * This class implements a number of automatic bookkeeping strategies for caching the results of computable nodes
- * and updating the status of the cached values after mutating the primitive nodes.
- *
- * The nodes may store any object that implements {@link Duplicable}. These objects provide a recipe for
- * making a deep copy of the value(s) that they hold by implementing {@link Duplicable#duplicate()}, and
- * {@link Duplicable#hasValue()} to indicate whether the object holds any null pointers.
+ * The {@link CacheNode}s can store any object that implements {@link Duplicable}. These objects provide a recipe for
+ * making a deep copy of the stored value(s) via {@link Duplicable#duplicate()}. If {@link Duplicable#hasValue()}
+ * is true, it indicates that the {@link Duplicable} currently stores a non-null Object.
  *
  * Typical use case: evaluating computationally expensive expressions with common subexpressions.
  *
  * Example: let X, Y and Z be three immutable values (primitive nodes) and we want to calculate f(X,Y) and g(f(X,Y),Z).
  * To this end, we may first calculate Q_1 = f(X,Y) and proceed to calculate Q_2 = g(f(X,Y),Z). By caching the value of
- * Q_1, we save ourselves recomputing the subexpression f(X,Y) every time we mutate the primitive value Z. Graphically,
- * the computation can be represented as a level-ordered directed acyclic graph (the edges are assumed to have downward
+ * Q_1, we save on recomputing the subexpression f(X,Y) every time we mutate the primitive value Z and we need g.
+ * Graphically, the computation can be represented as a topologically-ordered DAG (the edges are assumed to have downward
  * arrows):
  *
  *                X      Y   Z    (depth 0)
@@ -40,16 +41,14 @@ import java.util.stream.Collectors;
  *                    Q_2         (depth 2)
  *
  * One must manually identify the common subexpressions and assign a label to each. In the future, this can be
- * streamlined using a CAS library. The evaluation scheme can be conveniently set up using
- * {@link ImmutableComputableGraphBuilder} and its two main methods:
- * {@link ImmutableComputableGraphBuilder#addPrimitiveNode}, and
- * {@link ImmutableComputableGraphBuilder#addComputableNode}.
+ * streamlined using a CAS library. The {@link ImmutableComputableGraph} can be conveniently constructed using
+ * the builder pattern provided by {@link ImmutableComputableGraphBuilder}.
  *
  * Primitive nodes live at the top of the DAG and are specified by their key, initial value, and a set of tags.
  *
- * For computable nodes, one must provide a {@link ComputableNodeFunction}, a list of immediate parent nodes, a list of
- * tags, and whether or not the value is to be cached. Computable nodes come in 3 species depending on the way
- * they are constructed:
+ * For computable nodes, one must provide a {@link ComputableNodeFunction}, a list of parent nodes, a list of
+ * tags, and whether or not the value is to be cached. Computable nodes come in three different species depending on
+ * the way they are constructed:
  *
  *      (1) Caching: these nodes may store the values they evaluate for future lookup
  *      (2) Non-caching: these nodes are compute-on-demand
@@ -59,50 +58,54 @@ import java.util.stream.Collectors;
  *          out of date) based on the provided parents list.
  *
  * One can require the caching computable nodes to be updated and cached automatically after each mutation of a
- * primitive or externally-computed node by invoking {@link ImmutableComputableGraphBuilder#enableCacheAutoUpdate()}.
- * This feature, however, is NOT recommended as one may not need all the caches to be up-to-date at all times
- * (see below for updating caches selectively). This class throws an {@link IllegalStateException} if an old
- * cache is invoked in order to notify the user to update the cache manually.
+ * primitive or externally-computed node by invoking {@link ImmutableComputableGraphBuilder#withCacheAutoUpdate()}.
+ * This feature, however, is _not_ recommended as one may not need all the caches to be up-to-date at all times
+ * (see below for updating caches selectively). This class throws exceptions if an out-of-date cached value is queried
+ * in order to notify the user to update the cache manually.
  *
  * Updating caches:
  * ================
  *
  * If cache auto update is not enabled, the user is responsible for updating the caches by calling
  * either {@link #updateAllCaches()}, {@link #updateCachesForNode(String)}, or {@link #updateCachesForTag(String)}.
+ * These methods also come with counterparts {@link #updateAllCachesIfPossible()},
+ * {@link #updateCachesForNodeIfPossible(String)}, and {@link #updateCachesForTagIfPossible(String)}. These methods
+ * are safeguarded against throwing exceptions (e.g. if a required primitive or externally-computed value is not
+ * available) and try to update as many cache nodes as possible.
  *
  * Tags:
  * =====
  *
- * Tags are arbitrary names used for grouping nodes that are semantically related. The user may want to update the
+ * Tags are arbitrary string identifiers used for grouping nodes that are semantically related. The user may want to update the
  * nodes associated to the same tag simultaneously, for example, when performing an operation that requires updated
  * values for all nodes that denote subexpressions of a larger expression. In this case, the user will tag all nodes
  * that appear in the larger expression with a common name and calls {@link #updateCachesForTag(String)}.
  *
- * Tags are inherited from descendents to parents. In the above example, if Q_2 is tagged with {"FOO"}, Q_1 is tagged
- * with {"BAR"}, then X and Y both inherit {"FOO", "BAR"} tags whereas Z inherits {"FOO"}.
+ * Tags are inherited from descendents to ancestors. In the above example, if Q_2 is tagged with {"FOO"} and Q_1 is tagged
+ * with {"BAR"}, then X and Y both inherit {"FOO", "BAR"} tags whereas Z only inherits {"FOO"}.
  *
  * Querying:
  * =========
  *
- * The graph is queried either by calling {@link #getValueDirect(String)} or
- * {@link #getValueWithRequiredEvaluations(String)}. The former only fetches the values and throws an exception
- * if the some of the required caches are out of date, or a non-caching computable node is encountered.
- * The latter performs the required evaluations along the way.
+ * The graph is queried either by calling {@link #fetchDirectly(String)} or
+ * {@link #fetchWithRequiredEvaluations(String)}. The former only fetches the values and throws an exception
+ * if the some of the required nodes are out of date, or a non-caching computable node is queried. The latter performs
+ * the required _necessary_ evaluations along the way.
  *
  * IMPORTANT NOTE: the queried values are returned by reference. It is the user's responsibility not to mutate
- * them. Otherwise, the functional structure will be broken.
+ * them. Otherwise, immutability will be broken.
  *
  * Mutation:
  * =========
  *
- * The primitive values can be mutated by calling {@link ImmutableComputableGraph#setValue(String, Duplicable)}.
- * The mutations do not occur in place; rather, a new instance of {@link ImmutableComputableGraph} is created along
- * with new instances for the updated nodes. Immutability is desired, for instance, if this class is used as elements
- * of a {@link org.apache.spark.api.java.JavaRDD}. If cache auto update is enabled, the affected nodes will be evaluated.
- * Otherwise, only the cache status will go out of date. Unchanged nodes are passed as reference to the new instance.
- * JVM's garbage collector will free up the memory for old cached nodes in sequential computations.
+ * The primitive values can be mutated by calling {@link #setValue(String, Duplicable)}. Mutations do not occur in place;
+ * rather, a new instance of {@link ImmutableComputableGraph} is created along with new instances for the updated nodes.
+ * Immutability is desired, for instance, if this class is used as elements of a {@link org.apache.spark.api.java.JavaRDD}.
+ * If cache auto update is enabled, the affected nodes will be automatically computed and cached. Otherwise, only the
+ * cache status go out of date and the old stored values are {@code null}ed.
  *
- * TODO github/gatk-protected issue # 999 --- Improve ImmutableComputableGraph
+ * Note: the new {@link ImmutableComputableGraph} instance returned by {@link #setValue(String, Duplicable)} is _not_ a
+ * deep copy and may hold references to {@link CacheNode}s contained the previous instance(s).
  *
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
@@ -116,87 +119,17 @@ public final class ImmutableComputableGraph implements Serializable {
     private final boolean cacheAutoUpdate;
     private final ComputableGraphStructure cgs;
 
-    /**
-     * A simple builder class for {@link ImmutableComputableGraph}
-     */
-    public static class ImmutableComputableGraphBuilder {
-        private final Set<CacheNode> nodes;
-        private final Set<String> keys;
-        private boolean cacheAutoUpdate;
-
-        ImmutableComputableGraphBuilder() {
-            nodes = new HashSet<>();
-            keys = new HashSet<>();
-            cacheAutoUpdate = false;
-        }
-
-        public ImmutableComputableGraphBuilder addPrimitiveNode(@Nonnull final String key,
-                                                                @Nonnull final String[] tags,
-                                                                @Nonnull Duplicable value) {
-            Utils.nonNull(key);
-            Utils.nonNull(tags);
-            Utils.nonNull(value);
-            Utils.validateArg(!keys.contains(key), String.format("A node named \"%s\" already exists", key));
-            nodes.add(new PrimitiveCacheNode(key, Arrays.stream(tags).collect(Collectors.toList()), value));
-            keys.add(key);
-            return this;
-        }
-
-        public ImmutableComputableGraphBuilder addNDArrayPrimitiveNode(@Nonnull final String key) {
-            return addPrimitiveNode(key, new String[]{}, new DuplicableNDArray());
-        }
-
-        public ImmutableComputableGraphBuilder addComputableNode(@Nonnull final String key,
-                                                                 @Nonnull final String[] tags,
-                                                                 @Nonnull final String[] parents,
-                                                                 @Nullable final ComputableNodeFunction func,
-                                                                 final boolean cacheEvals) {
-            Utils.nonNull(key);
-            Utils.nonNull(tags);
-            Utils.nonNull(parents);
-            Utils.validateArg(!keys.contains(key), String.format("A node named \"%s\" already exists", key));
-            nodes.add(new ComputableCacheNode(key,
-                    Arrays.stream(tags).collect(Collectors.toList()),
-                    Arrays.stream(parents).collect(Collectors.toList()),
-                    func, cacheEvals));
-            keys.add(key);
-            return this;
-        }
-
-        public ImmutableComputableGraphBuilder addExternallyComputableNode(@Nonnull final String key) {
-            return addComputableNode(key, new String[] {}, new String[] {}, null, true);
-        }
-
-        public ImmutableComputableGraphBuilder enableCacheAutoUpdate() {
-            cacheAutoUpdate = true;
-            return this;
-        }
-
-        public ImmutableComputableGraphBuilder disableCacheAutoUpdate() {
-            cacheAutoUpdate = false;
-            return this;
-        }
-
-        public ImmutableComputableGraph build() {
-            if (nodes.size() == 0) {
-                throw new IllegalStateException("Can not make an empty cache node collection");
-            } else {
-                return new ImmutableComputableGraph(nodes, cacheAutoUpdate);
-            }
-        }
-    }
-
     public static ImmutableComputableGraphBuilder builder() {
         return new ImmutableComputableGraphBuilder();
     }
 
     /**
-     * Private constructor from a node collection (used by the builder).
+     * Package-private constructor from a node collection (used by the builder).
      *
      * @param nodeSet a collection of {@link CacheNode}s
      */
-    private ImmutableComputableGraph(@Nonnull final Set<CacheNode> nodeSet,
-                                     final boolean cacheAutoUpdate) {
+    ImmutableComputableGraph(@Nonnull final Set<CacheNode> nodeSet,
+                             final boolean cacheAutoUpdate) {
         Utils.nonNull(nodeSet, "The nodes collection must be non-null.");
         this.cacheAutoUpdate = cacheAutoUpdate;
         nodesMap = nodeSet.stream().collect(Collectors.toMap(CacheNode::getKey, Function.identity()));
@@ -229,36 +162,25 @@ public final class ImmutableComputableGraph implements Serializable {
     public ImmutableComputableGraph setValue(@Nonnull final String nodeKey,
                                              @Nonnull final Duplicable newValue)
             throws IllegalArgumentException, UnsupportedOperationException {
-        assertNodeExists(nodeKey);
-        CacheNode node = nodesMap.get(nodeKey);
-        if (!node.isExternallyComputable()) {
+        CacheNode node = nodesMap.get(assertNodeExists(nodeKey));
+        if (!node.isExternallyComputed()) {
             throw new UnsupportedOperationException("Can not explicitly set the value of a non-primitive cache node.");
         }
         final Map<String, CacheNode> updatedNodesMap = new HashMap<>();
         updatedNodesMap.put(nodeKey, node.duplicateWithUpdatedValue(newValue));
         final ImmutableComputableGraph out = duplicateWithUpdatedNodes(
-                addDuplicateOfOutdatedDescendents(nodeKey, updatedNodesMap));
+                addDuplicateOfOutdatedDescendants(nodeKey, updatedNodesMap));
         if (cacheAutoUpdate) {
-            Map<String, Duplicable> accumulatedValues = out.evaluateInTopologicalOrder(
-                    cgs.getTopologicalOrderForNodeMutation(nodeKey));
-            return out.updateCachesFromAccumulatedValues(accumulatedValues);
-        } else {
-            return out;
+            try { /* try to update caches; it is not guaranteed if some of the nodes are not initialized */
+                final Map<String, Duplicable> accumulatedValues = out.evaluateInTopologicalOrder(
+                        cgs.getTopologicalOrderForNodeMutation(nodeKey));
+                return out.updateCachesFromAccumulatedValues(accumulatedValues);
+            } catch (final PrimitiveCacheNode.PrimitiveValueNotInitializedException |
+                    ComputableCacheNode.ExternallyComputableNodeValueUnavailableException ex) {
+                /* cache auto-update failed; will return "out" = ICG with updated node and outdated descendents */
+            }
         }
-    }
-
-    /**
-     * Nullifies the cached value of a node (both computable and primitive)
-     *
-     * @param nodeKey key of the node to be nullified
-     * @return a new instance of {@link ImmutableComputableGraph}
-     * @throws IllegalArgumentException if the node does not exist
-     */
-    public ImmutableComputableGraph nullifyNode(@Nonnull final String nodeKey)
-            throws IllegalArgumentException {
-        assertNodeExists(nodeKey);
-        CacheNode oldNode = nodesMap.get(nodeKey);
-        return duplicateWithUpdatedNodes(ImmutableMap.of(nodeKey, oldNode.duplicateWithUpdatedValue(null)));
+        return out;
     }
 
     /**
@@ -268,9 +190,9 @@ public final class ImmutableComputableGraph implements Serializable {
      * @param key key of the updated node
      * @param updatedNodesMap a key -> node map
      */
-    private Map<String, CacheNode> addDuplicateOfOutdatedDescendents(@Nonnull final String key,
+    private Map<String, CacheNode> addDuplicateOfOutdatedDescendants(@Nonnull final String key,
                                                                      @Nonnull final Map<String, CacheNode> updatedNodesMap) {
-        for (final String descendant : cgs.getAllDescendents(key)) {
+        for (final String descendant : cgs.getDescendants(key)) {
             CacheNode oldDescendant = nodesMap.get(descendant);
             /* all of the descendants are computable nodes and can be safely up-casted */
             updatedNodesMap.put(descendant, ((ComputableCacheNode)oldDescendant).duplicateWithOutdatedCacheStatus());
@@ -281,7 +203,7 @@ public final class ImmutableComputableGraph implements Serializable {
     /**
      * Returns a reference to the value of a given node
      *
-     * Note: this function is purposefully meant to be light:
+     * Note: this function is purposefully meant to be _light_ in the following sense:
      *
      * (1) it does not update out-of-date caching computable nodes, and
      * (2) it does not evaluate non-caching computable nodes.
@@ -292,21 +214,31 @@ public final class ImmutableComputableGraph implements Serializable {
      *                               not initialized
      * @throws IllegalArgumentException if the node does not exist
      */
-    public Duplicable getValueDirect(@Nonnull final String nodeKey) throws IllegalStateException, IllegalArgumentException {
-        assertNodeExists(nodeKey);
-        return nodesMap.get(nodeKey).get(EMPTY_MAP);
+    public Duplicable fetchDirectly(@Nonnull final String nodeKey) throws IllegalArgumentException {
+        return nodesMap.get(assertNodeExists(nodeKey)).get(EMPTY_MAP);
     }
 
     /**
+     * Returns the value of a node. If the node is computable and its value is not available, all of the required
+     * intermediate calculations will be done.
+     *
+     * Note: the result of intermediate calculations are _not_ stored back into the (possibly out-of-date) ancestor
+     * nodes. This may result in redundant calculations. In generic situations, the most efficient approach is to
+     * update the required cache nodes first, and then fetch the up-to-date cached values using
+     * {@link #fetchDirectly(String)} instead.
      *
      * @param nodeKey key of the node
      * @return value of the node
      * @throws IllegalArgumentException if the node does not exist
      */
-    public Duplicable getValueWithRequiredEvaluations(@Nonnull final String nodeKey)
+    public Duplicable fetchWithRequiredEvaluations(@Nonnull final String nodeKey)
             throws IllegalStateException, IllegalArgumentException {
-        assertNodeExists(nodeKey);
-        return evaluateInTopologicalOrder(cgs.getTopologicalOrderForNodeEvaluation(nodeKey)).get(nodeKey);
+        final CacheNode node = nodesMap.get(assertNodeExists(nodeKey));
+        if (node.hasValue()) {
+            return node.get(EMPTY_MAP);
+        } else {
+            return evaluateInTopologicalOrder(cgs.getTopologicalOrderForNodeEvaluation(nodeKey)).get(nodeKey);
+        }
     }
 
     /**
@@ -321,7 +253,7 @@ public final class ImmutableComputableGraph implements Serializable {
      *
      * Note: this method does not check whether {@code topologicallyOrderedNodeKeys} is actually topologically ordered.
      *
-     * @param topologicallyOrderedNodeKeys depth-sorted list of nodes
+     * @param topologicallyOrderedNodeKeys topologically sorted list of nodes
      * @throws ComputableNodeFunction.ParentValueNotFoundException if a parent value required for a computation function
      *         is not found; it can be thrown if {@code topologicallyOrderedNodeKeys} is not truly topologically ordered
      * @throws ComputableCacheNode.ExternallyComputableNodeValueUnavailableException if the value of an externally computable
@@ -339,6 +271,30 @@ public final class ImmutableComputableGraph implements Serializable {
     }
 
     /**
+     * This method is the same as {@link #evaluateInTopologicalOrder(List)} except for it catches all exceptions
+     * that would otherwise be thrown by {@link #evaluateInTopologicalOrder(List)}, and performs a partial evaluation
+     * to the possible extent
+     *
+     * @param topologicallyOrderedNodeKeys topologically sorted list of nodes
+     * @return a map from node keys to their values accumulated during computation
+     */
+    private Map<String, Duplicable> evaluateInTopologicalOrderIfPossible(@Nonnull final List<String> topologicallyOrderedNodeKeys) {
+        final Map<String, Duplicable> accumulatedValues = new HashMap<>();
+        for (final String nodeKey : topologicallyOrderedNodeKeys) {
+            Duplicable value = null;
+            try {
+                value = nodesMap.get(nodeKey).get(accumulatedValues);
+            } catch (final Exception ex) {
+                /* do nothing */
+            }
+            if (value != null) {
+                accumulatedValues.put(nodeKey, value);
+            }
+        }
+        return accumulatedValues;
+    }
+
+    /**
      * Check {@code accumulatedValues} for truly affected nodes, create new node instances for affected nodes,
      * and make a new instance of {@link ImmutableComputableGraph} with reference to unaffected nodes, and new nodes
      *
@@ -351,9 +307,9 @@ public final class ImmutableComputableGraph implements Serializable {
         return duplicateWithUpdatedNodes(
                 accumulatedValues.keySet().stream()
                         /* filter out primitives and caching nodes that are current */
-                        .filter(node -> !nodesMap.get(node).isPrimitive() &&
-                                ((ComputableCacheNode)nodesMap.get(node)).doesCacheEvaluations() &&
-                                !((ComputableCacheNode)nodesMap.get(node)).isCacheCurrent())
+                        .filter(node -> !(nodesMap.get(node).isPrimitive() ||
+                                nodesMap.get(node).hasValue() ||
+                                !((ComputableCacheNode)nodesMap.get(node)).isCaching()))
                         /* collect to a map: key -> duplicated node with updated value */
                         .collect(Collectors.toMap(Function.identity(), node ->
                                 ((ComputableCacheNode)nodesMap.get(node))
@@ -362,33 +318,66 @@ public final class ImmutableComputableGraph implements Serializable {
 
     /**
      * Update the cached values by node key
+     *
      * @return a new instance of {@link ImmutableComputableGraph} with new instances of updated nodes
      */
     public ImmutableComputableGraph updateCachesForNode(@Nonnull final String nodeKey) {
-        assertNodeExists(nodeKey);
-        final Map<String, Duplicable> accumulatedValues = evaluateInTopologicalOrder(
-                cgs.getTopologicalOrderForNodeEvaluation(nodeKey));
-        return updateCachesFromAccumulatedValues(accumulatedValues);
+        return evaluateAndUpdateCaches(this::evaluateInTopologicalOrder,
+                cgs.getTopologicalOrderForNodeEvaluation(assertNodeExists(nodeKey)));
+    }
+
+    /**
+     * Update the cached values by node key
+     *
+     * @return a new instance of {@link ImmutableComputableGraph} with new instances of updated nodes
+     */
+    public ImmutableComputableGraph updateCachesForNodeIfPossible(@Nonnull final String nodeKey) {
+        return evaluateAndUpdateCaches(this::evaluateInTopologicalOrderIfPossible,
+                cgs.getTopologicalOrderForNodeEvaluation(assertNodeExists(nodeKey)));
     }
 
     /**
      * Update the cached values by tag
+     *
      * @return a new instance of {@link ImmutableComputableGraph} with new instances of updated nodes
      */
     public ImmutableComputableGraph updateCachesForTag(final String tagKey) {
-        assertTagExists(tagKey);
-        final Map<String, Duplicable> accumulatedValues = evaluateInTopologicalOrder(cgs.getTopologicalOrderForTagEvaluation(tagKey));
-        return updateCachesFromAccumulatedValues(accumulatedValues);
+        return evaluateAndUpdateCaches(this::evaluateInTopologicalOrder,
+                cgs.getTopologicalOrderForTagEvaluation(assertTagExists(tagKey)));
     }
 
     /**
-     * Update all caches values
+     * Update all possibly updatable tagged caching nodes
+     *
+     * @return a new instance of {@link ImmutableComputableGraph} with new instances of updated nodes
+     */
+    public ImmutableComputableGraph updateCachesForTagIfPossible(final String tagKey) {
+        return evaluateAndUpdateCaches(this::evaluateInTopologicalOrderIfPossible,
+                cgs.getTopologicalOrderForTagEvaluation(assertTagExists(tagKey)));
+    }
+
+    /**
+     * Update all caching nodes
+     *
      * @return a new instance of {@link ImmutableComputableGraph} with new instances of updated nodes
      */
     public ImmutableComputableGraph updateAllCaches() {
-        final Map<String, Duplicable> accumulatedValues = evaluateInTopologicalOrder(
-                cgs.getTopologicalOrderForCompleteEvaluation());
-        return updateCachesFromAccumulatedValues(accumulatedValues);
+        return evaluateAndUpdateCaches(this::evaluateInTopologicalOrder, cgs.getTopologicalOrderForCompleteEvaluation());
+    }
+
+    /**
+     * Update all possibly updatable caches
+     *
+     * @return a new instance of {@link ImmutableComputableGraph} with new instances of updated nodes
+     */
+    public ImmutableComputableGraph updateAllCachesIfPossible() {
+        return evaluateAndUpdateCaches(this::evaluateInTopologicalOrderIfPossible, cgs.getTopologicalOrderForCompleteEvaluation());
+    }
+
+    private ImmutableComputableGraph evaluateAndUpdateCaches(
+            @Nonnull final Function<List<String>, Map<String, Duplicable>> topologicalEvaluator,
+            @Nonnull final List<String> topologicallyOrderedNodeKeys) {
+        return updateCachesFromAccumulatedValues(topologicalEvaluator.apply(topologicallyOrderedNodeKeys));
     }
 
     /**
@@ -399,22 +388,40 @@ public final class ImmutableComputableGraph implements Serializable {
      */
     private ImmutableComputableGraph duplicateWithUpdatedNodes(final Map<String, CacheNode> updatedNodesMap) {
         final Map<String, CacheNode> newNodesMap = new HashMap<>();
-        /* nodes that are present in the new map */
+        final Set<String> updatedNodeKeys = updatedNodesMap.keySet();
+        /* intact nodes */
         cgs.getNodeKeysSet().stream()
-                .filter(node -> !updatedNodesMap.keySet().contains(node))
+                .filter(node -> !updatedNodeKeys.contains(node))
                 .forEach(node -> newNodesMap.put(node, nodesMap.get(node)));
+        /* updated nodes */
         newNodesMap.putAll(updatedNodesMap);
         return new ImmutableComputableGraph(newNodesMap, cgs, cacheAutoUpdate);
     }
 
-    private void assertNodeExists(final String nodeKey) {
-        Utils.nonNull(nodeKey, "The node key must be non-null");
-        Utils.validateArg(cgs.getNodeKeysSet().contains(nodeKey), "The node \"" + nodeKey + "\" does not exist.");
+    public boolean isValueDirectlyAvailable(final String nodeKey) {
+        return nodesMap.get(assertNodeExists(nodeKey)).hasValue();
     }
 
-    private void assertTagExists(final String tagKey) {
+    private String assertNodeExists(final String nodeKey) {
+        Utils.nonNull(nodeKey, "The node key must be non-null");
+        Utils.validateArg(cgs.getNodeKeysSet().contains(nodeKey), "The node" + ImmutableComputableGraphUtils.quote(nodeKey) + " does not exist.");
+        return nodeKey;
+    }
+
+    private String assertTagExists(final String tagKey) {
         Utils.nonNull(tagKey, "The tag key must be non-null");
-        Utils.validateArg(cgs.getNodeTagsSet().contains(tagKey), "The tag \"" + tagKey + "\" does not exist.");
+        Utils.validateArg(cgs.getNodeTagsSet().contains(tagKey), "The tag " + ImmutableComputableGraphUtils.quote(tagKey) + " does not exist.");
+        return tagKey;
+    }
+
+    @VisibleForTesting
+    ComputableGraphStructure getComputableGraphStructure() {
+        return cgs;
+    }
+
+    @VisibleForTesting
+    CacheNode getCacheNode(@Nonnull final String nodeKey) {
+        return nodesMap.get(assertNodeExists(nodeKey));
     }
 
     @Override
@@ -425,15 +432,14 @@ public final class ImmutableComputableGraph implements Serializable {
             out += "\ttype: " + (nodesMap.get(key).isPrimitive() ? "primitive" : "computable") + "\n";
             String value;
             try {
-                value = getValueDirect(key).toString();
-            } catch (final IllegalStateException | NullPointerException e) {
+                value = fetchDirectly(key).toString();
+            } catch (final Exception ex) {
                 value = "not available";
             }
             out += "\tvalue: " + value + "\n";
             if (!nodesMap.get(key).isPrimitive()) {
-                out += "\tup to date: " + ((ComputableCacheNode)nodesMap.get(key)).isStoredValueAvailableAndCurrent() + "\n";
-                out += "\tcaches values: " + ((ComputableCacheNode)nodesMap.get(key)).doesCacheEvaluations() + "\n";
-                out += "\thas a value: " + nodesMap.get(key).isStoredValueAvailable() + "\n";
+                out += "\tcaches values: " + ((ComputableCacheNode)nodesMap.get(key)).isCaching() + "\n";
+                out += "\thas a value: " + nodesMap.get(key).hasValue() + "\n";
             }
         }
         return out;

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ImmutableComputableGraphUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ImmutableComputableGraphUtils.java
@@ -1,0 +1,115 @@
+package org.broadinstitute.hellbender.tools.coveragemodel.cachemanager;
+
+import org.broadinstitute.hellbender.utils.Utils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A utilities class for {@link ImmutableComputableGraph}.
+ *
+ * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
+ */
+public final class ImmutableComputableGraphUtils {
+
+    private ImmutableComputableGraphUtils() {}
+
+    /**
+     * A simple builder class for {@link ImmutableComputableGraph}.
+     *
+     * @implNote Node addition methods must perform node key uniqueness checks. Otherwise, some of the nodes
+     * with the same key will be lost; see {@link CacheNode#equals(Object)}.
+     */
+    public static class ImmutableComputableGraphBuilder {
+        private final Set<CacheNode> nodes;
+        private final Set<String> keys;
+        private boolean cacheAutoUpdate;
+
+        ImmutableComputableGraphBuilder() {
+            nodes = new HashSet<>();
+            keys = new HashSet<>();
+            cacheAutoUpdate = false;
+        }
+
+        public ImmutableComputableGraphBuilder primitiveNode(@Nonnull final String key,
+                                                             @Nonnull final String[] tags,
+                                                             @Nonnull Duplicable value) {
+            Utils.nonNull(key);
+            Utils.nonNull(tags);
+            Utils.nonNull(value);
+            assertKeyUniqueness(key);
+            nodes.add(new PrimitiveCacheNode(key, Arrays.stream(tags).collect(Collectors.toList()), value));
+            keys.add(key);
+            return this;
+        }
+
+
+        public ImmutableComputableGraphBuilder primitiveNodeWithEmptyNDArray(@Nonnull final String key) {
+            return primitiveNode(key, new String[]{}, new DuplicableNDArray());
+        }
+
+        public ImmutableComputableGraphBuilder computableNode(@Nonnull final String key,
+                                                              @Nonnull final String[] tags,
+                                                              @Nonnull final String[] parents,
+                                                              @Nullable final ComputableNodeFunction func,
+                                                              final boolean cacheEvals) {
+            Utils.nonNull(key);
+            Utils.nonNull(tags);
+            Utils.nonNull(parents);
+            assertKeyUniqueness(key);
+            nodes.add(new ComputableCacheNode(key,
+                    Arrays.stream(tags).collect(Collectors.toList()),
+                    Arrays.stream(parents).collect(Collectors.toList()),
+                    func, cacheEvals));
+            keys.add(key);
+            return this;
+        }
+
+        public ImmutableComputableGraphBuilder externallyComputableNode(@Nonnull final String key) {
+            return computableNode(key, new String[] {}, new String[] {}, null, true);
+        }
+
+        public ImmutableComputableGraphBuilder withCacheAutoUpdate() {
+            cacheAutoUpdate = true;
+            return this;
+        }
+
+        public ImmutableComputableGraphBuilder withoutCacheAutoUpdate() {
+            cacheAutoUpdate = false;
+            return this;
+        }
+
+        private void assertKeyUniqueness(@Nonnull final String key) {
+            if (keys.contains(key)) {
+                throw new DuplicateNodeKeyException("A node with key " + quote(key) + " already exists");
+            }
+        }
+
+        public ImmutableComputableGraph build() {
+            if (nodes.size() == 0) {
+                throw new IllegalStateException("Can not make an empty cache node collection");
+            } else {
+                return new ImmutableComputableGraph(nodes, cacheAutoUpdate);
+            }
+        }
+
+        /**
+         * This exception will be thrown if a node with the same key is already added to the builder
+         */
+        static final class DuplicateNodeKeyException extends RuntimeException {
+            private static final long serialVersionUID = 2016242121833170379L;
+
+            DuplicateNodeKeyException(String s) {
+                super(s);
+            }
+        }
+    }
+
+    static String quote(final String str) {
+        return "\"" + str + "\"";
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/PrimitiveCacheNode.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/PrimitiveCacheNode.java
@@ -12,37 +12,37 @@ import java.util.Map;
  *
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
-public final class PrimitiveCacheNode extends CacheNode {
+final class PrimitiveCacheNode extends CacheNode {
 
     private Duplicable value = null;
 
     @Override
-    public boolean isPrimitive() { return true; }
+    boolean isPrimitive() { return true; }
 
     @Override
-    public boolean isExternallyComputable() { return true; }
+    boolean isExternallyComputed() { return true; }
 
     @Override
-    public void set(@Nullable final Duplicable val) {
+    void set(@Nullable final Duplicable val) {
         value = val;
     }
 
-    public PrimitiveCacheNode(@Nonnull final String key,
-                              @Nonnull final Collection<String> tags,
-                              @Nullable final Duplicable val) {
+    PrimitiveCacheNode(@Nonnull final String key,
+                       @Nonnull final Collection<String> tags,
+                       @Nullable final Duplicable val) {
         super(key, tags, Collections.emptyList());
         set(val);
     }
 
     @Override
-    public boolean isStoredValueAvailable() {
-        return value != null && !value.hasValue();
+    boolean hasValue() {
+        return value != null && value.hasValue();
     }
 
     @Override
-    public Duplicable get(@Nullable final Map<String, Duplicable> parentsValues)
+    Duplicable get(@Nullable final Map<String, Duplicable> parentsValues)
             throws PrimitiveValueNotInitializedException {
-        if (isStoredValueAvailable()) {
+        if (hasValue()) {
             return value;
         } else {
             throw new PrimitiveValueNotInitializedException(String.format(
@@ -51,8 +51,8 @@ public final class PrimitiveCacheNode extends CacheNode {
     }
 
     @Override
-    public PrimitiveCacheNode duplicate() {
-        if (value != null && !value.hasValue()) {
+    PrimitiveCacheNode duplicate() {
+        if (hasValue()) {
             return new PrimitiveCacheNode(getKey(), getTags(), value.duplicate());
         } else {
             return new PrimitiveCacheNode(getKey(), getTags(), null);
@@ -60,7 +60,7 @@ public final class PrimitiveCacheNode extends CacheNode {
     }
 
     @Override
-    public PrimitiveCacheNode duplicateWithUpdatedValue(final Duplicable newValue) {
+    PrimitiveCacheNode duplicateWithUpdatedValue(final Duplicable newValue) {
         return new PrimitiveCacheNode(getKey(), getTags(), newValue);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/MathObjectAsserts.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/MathObjectAsserts.java
@@ -2,7 +2,9 @@ package org.broadinstitute.hellbender.utils;
 
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.util.FastMath;
+import org.nd4j.linalg.api.ndarray.INDArray;
 import org.testng.Assert;
+import org.testng.internal.junit.ArrayAsserts;
 
 /**
  * This class provides useful assertions about approximate equality of various mathematical objects
@@ -15,6 +17,28 @@ public class MathObjectAsserts {
     public static final double DEFAULT_ABSOLUTE_TOLERANCE = 1e-10;
 
     private MathObjectAsserts() {}
+
+    public static void assertNDArrayEquals(final INDArray actual, final INDArray expected,
+                                           final double relativeTolerance, final double absoluteTolerance) {
+        Assert.assertNotNull(expected);
+        Assert.assertNotNull(actual);
+        ArrayAsserts.assertArrayEquals(actual.shape(), expected.shape());
+        final double[] actualAsArray = actual.reshape(1, actual.length()).dup().data().asDouble();
+        final double[] expectedAsArray = expected.reshape(1, actual.length()).dup().data().asDouble();
+        Assert.assertEquals(actualAsArray.length, expected.length());
+        for (int i = 0; i < actualAsArray.length; i++) {
+            assertDoubleEquals(actualAsArray[i], expectedAsArray[i], relativeTolerance, absoluteTolerance);
+        }
+    }
+
+    public static void assertNDArrayEquals(final INDArray actual, final INDArray expected,
+                                           final double relativeTolerance) {
+        assertNDArrayEquals(actual, expected, relativeTolerance, DEFAULT_ABSOLUTE_TOLERANCE);
+    }
+
+    public static void assertNDArrayEquals(final INDArray actual, final INDArray expected) {
+        assertNDArrayEquals(actual, expected, DEFAULT_RELATIVE_TOLERANCE, DEFAULT_ABSOLUTE_TOLERANCE);
+    }
 
     public static void assertRealMatrixEquals(final RealMatrix actual, final RealMatrix expected,
                                               final double relativeTolerance, final double absoluteTolerance) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ComputableGraphStructureUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ComputableGraphStructureUnitTest.java
@@ -1,19 +1,359 @@
 package org.broadinstitute.hellbender.tools.coveragemodel.cachemanager;
 
-import junit.framework.AssertionFailedError;
+import avro.shaded.com.google.common.collect.ImmutableMap;
+import avro.shaded.com.google.common.collect.Sets;
+import org.apache.commons.lang.RandomStringUtils;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 /**
- * Unit tests for {@link ComputableGraphStructure}
- *
- * TODO github/gatk-protected issue #803
+ * Unit tests for {@link ComputableGraphStructure}.
  *
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class ComputableGraphStructureUnitTest extends BaseTest {
-    @Test(enabled = false)
-    public void test() {
-        throw new AssertionFailedError("Test is not implemented yet");
+
+    private static final Random rng = new Random(1984);
+    private static final int MAX_DAG_DEPTH = 10;
+    private static final int MAX_NODES_PER_LAYER = 10;
+    private static final int MAX_TAGS_PER_NODE = 10;
+    private static final int MAX_PARENTS_PER_NODE = 10;
+    private static final int NUM_TRIALS = 5;
+
+    @Test(expectedExceptions = ComputableGraphStructure.NonexistentParentNodeKey.class)
+    public void testMissingParents() {
+        ImmutableComputableGraph.builder()
+                .primitiveNode("x", new String[] {}, new DuplicableNDArray())
+                .primitiveNode("y", new String[] {}, new DuplicableNumber<Double>())
+                .primitiveNode("z", new String[] {}, new DuplicableNDArray())
+                .computableNode("f", new String[] {}, new String[] {"x", "y", "q"}, null, true) /* q is undefined */
+                .computableNode("g", new String[] {}, new String[] {"y", "z"}, null, true)
+                .computableNode("h", new String[] {}, new String[] {"f", "g"}, null, true)
+                .build();
+    }
+
+    @Test(expectedExceptions = ComputableGraphStructure.CyclicGraphException.class)
+    public void testCyclicGraphException_1() {
+        ImmutableComputableGraph.builder()
+                .primitiveNode("x", new String[] {}, new DuplicableNDArray())
+                .computableNode("y", new String[] {}, new String[] {"x", "w"}, null, true) /* cycle */
+                .computableNode("z", new String[] {}, new String[] {"y"}, null, true)
+                .computableNode("w", new String[] {}, new String[] {"z"}, null, true)
+                .build();
+    }
+
+    @Test(expectedExceptions = ComputableGraphStructure.CyclicGraphException.class)
+    public void testCyclicGraphException_2() {
+        ImmutableComputableGraph.builder()
+                .primitiveNode("x", new String[] {}, new DuplicableNDArray())
+                .primitiveNode("y", new String[] {}, new DuplicableNDArray())
+                .primitiveNode("z", new String[] {}, new DuplicableNDArray())
+                .computableNode("f", new String[] {}, new String[] {"x", "y", "h"}, null, true) /* cycle */
+                .computableNode("g", new String[] {}, new String[] {"y", "z"}, null, true)
+                .computableNode("h", new String[] {}, new String[] {"f", "g"}, null, true)
+                .build();
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testNodeTagsAndKeys() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        final Set<String> cgsNodeTagsSet = cgs.getNodeTagsSet();
+        final Set<String> dagNodeTagsSet = dag.tagsSet;
+        final Set<String> cgsNodeKeysSet = cgs.getNodeKeysSet();
+        final Set<String> dagNodeKeysSet = dag.nodeKeysSet;
+        Assert.assertTrue(cgsNodeKeysSet.equals(dagNodeKeysSet));
+        Assert.assertTrue(cgsNodeTagsSet.equals(dagNodeTagsSet));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testTopologicalOrder() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        dag.nodeKeysSet.forEach(nodeKey -> Assert.assertTrue(dag.topologicalOrderMap.get(nodeKey) ==
+                cgs.getTopologicalOrder(nodeKey)));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testAncestors() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        dag.nodeKeysSet.forEach(nodeKey -> Assert.assertTrue(dag.getAncestors(nodeKey).equals(cgs.getAncestors(nodeKey))));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testDescendants() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        dag.nodeKeysSet.forEach(nodeKey -> Assert.assertTrue(dag.getDescendents(nodeKey).equals(cgs.getDescendants(nodeKey))));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testParents() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        dag.nodeKeysSet.forEach(nodeKey -> Assert.assertTrue(dag.getParents(nodeKey).equals(cgs.getParents(nodeKey))));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testChildren() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        dag.nodeKeysSet.forEach(nodeKey -> Assert.assertTrue(dag.getChildren(nodeKey).equals(cgs.getChildren(nodeKey))));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testInducedTags() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        dag.nodeKeysSet.forEach(nodeKey -> Assert.assertTrue(dag.getInducedTags(nodeKey).equals(cgs.getInducedTagsForNode(nodeKey))));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testTopologicalOrderForNodeEvaluation() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        dag.nodeKeysSet.forEach(nodeKey -> Assert.assertTrue(isTopologicallyEquivalent(dag.getTopologicalOrderForNodeEvaluation(nodeKey),
+                cgs.getTopologicalOrderForNodeEvaluation(nodeKey), dag.topologicalOrderMap)));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testTopologicalOrderForNodeMutation() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        dag.nodeKeysSet.forEach(nodeKey -> Assert.assertTrue(isTopologicallyEquivalent(dag.getTopologicalOrderForNodeMutation(nodeKey),
+                cgs.getTopologicalOrderForNodeMutation(nodeKey), dag.topologicalOrderMap)));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testTopologicalOrderForTagEvaluation() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        dag.tagsSet.forEach(tag -> Assert.assertTrue(isTopologicallyEquivalent(dag.getTopologicalOrderForTagEvaluation(tag),
+                cgs.getTopologicalOrderForTagEvaluation(tag), dag.topologicalOrderMap)));
+    }
+
+    @Test(invocationCount = NUM_TRIALS)
+    public void testTopologicalOrderForCompleteEvaluation() {
+        final RandomDAG dag = RandomDAG.getRandomDAG();
+        final ComputableGraphStructure cgs = new ComputableGraphStructure(dag.getEquivalentCacheNodeSet());
+        final List<String> orderedNodes = new ArrayList<>(dag.nodeKeysSet);
+        orderedNodes.sort(Comparator.comparingInt(dag.topologicalOrderMap::get));
+        Assert.assertTrue(isTopologicallyEquivalent(cgs.getTopologicalOrderForCompleteEvaluation(), orderedNodes,
+                dag.topologicalOrderMap));
+    }
+
+    @Test
+    public void testAssertTopologicallyEquivalentLists() {
+        final Map<String, Integer> topologicalOrderMap = ImmutableMap.<String, Integer>builder()
+                .put("a0", 0).put("b0", 0).put("c0", 0)
+                .put("a1", 1).put("b1", 1).put("c1", 1)
+                .put("a2", 2).put("b2", 2).put("c2", 2).put("d2", 2).build();
+        Assert.assertTrue(isTopologicallyEquivalent(
+                Arrays.asList("a0", "c0", "a2", "d2"),
+                Arrays.asList("c0", "a0", "a2", "d2"),
+                topologicalOrderMap));
+        Assert.assertTrue(isTopologicallyEquivalent(
+                Arrays.asList("a0", "c0", "b1", "a1", "c1", "a2", "d2"),
+                Arrays.asList("c0", "a0", "b1", "c1", "a1", "a2", "d2"),
+                topologicalOrderMap));
+        Assert.assertTrue(!isTopologicallyEquivalent(
+                Arrays.asList("c0", "a2", "d2"),
+                Arrays.asList("c0", "a0", "a2", "d2"),
+                topologicalOrderMap));
+        Assert.assertTrue(!isTopologicallyEquivalent(
+                Arrays.asList("a0", "c0", "b1", "a1", "c1", "a2", "c2"),
+                Arrays.asList("c0", "a0", "b1", "c1", "a1", "a2", "d2"),
+                topologicalOrderMap));
+    }
+
+    /**
+     * This test helper class creates a random DAG starting from a topological order. All helper methods are
+     * implemented in a brute-force manner.
+     */
+    private static final class RandomDAG {
+        private static final int TAG_LENGTH = 32;
+        private static final int NODE_KEY_LENGTH = 32;
+
+        final Map<Integer, Set<String>> nodesByTopologicalOrder;
+        final Map<String, Integer> topologicalOrderMap;
+        final Map<String, Set<String>> parentsMap;
+        final Map<String, Set<String>> tagsMap;
+        final Set<String> nodeKeysSet;
+        final Set<String> tagsSet;
+
+        private RandomDAG(final int depth, final int maxNodesPerLayer, final int maxParentsPerNode, final int maxTagsPerNode) {
+            Utils.validateArg(depth >= 0, "DAG depth must be  >= 0");
+            Utils.validateArg(maxNodesPerLayer > 0, "Max nodes per layer must be positive");
+            Utils.validateArg(maxParentsPerNode > 0, "Max parents per node must be positive");
+            Utils.validateArg(maxTagsPerNode > 0, "Max tags per node must be positive");
+
+            nodesByTopologicalOrder = new HashMap<>();
+            parentsMap = new HashMap<>();
+            tagsMap = new HashMap<>();
+            nodeKeysSet = new HashSet<>();
+
+            for (int d = 0; d <= depth; d++) {
+                final Set<String> randomNodes = getRandomNodeKeys(maxNodesPerLayer);
+                nodeKeysSet.addAll(randomNodes);
+                nodesByTopologicalOrder.put(d, randomNodes);
+                randomNodes.forEach(nodeKey -> tagsMap.put(nodeKey, getRandomTags(maxTagsPerNode)));
+                randomNodes.forEach(nodeKey -> parentsMap.put(nodeKey, new HashSet<>()));
+                if (d > 0) {
+                    final Set<String> possibleAncestors = IntStream.range(0, d)
+                            .mapToObj(nodesByTopologicalOrder::get)
+                            .flatMap(Set::stream)
+                            .collect(Collectors.toSet());
+                    for (final String nodeKey : randomNodes) {
+                        final String randomParent = getRandomElement(nodesByTopologicalOrder.get(d - 1));
+                        final int numParents = rng.nextInt(maxParentsPerNode);
+                        final Set<String> randomAncestors = IntStream.range(0, numParents)
+                                .mapToObj(i -> getRandomElement(possibleAncestors))
+                                .collect(Collectors.toSet());
+                        parentsMap.put(nodeKey, new HashSet<>());
+                        parentsMap.get(nodeKey).add(randomParent);
+                        parentsMap.get(nodeKey).addAll(randomAncestors);
+                    }
+                }
+            }
+            topologicalOrderMap = new HashMap<>();
+            nodesByTopologicalOrder.entrySet().forEach(entry -> entry.getValue()
+                    .forEach(nodeKey -> topologicalOrderMap.put(nodeKey, entry.getKey())));
+            tagsSet = tagsMap.values().stream().flatMap(Set::stream).collect(Collectors.toSet());
+        }
+
+        static RandomDAG getRandomDAG() {
+            return new RandomDAG(rng.nextInt(MAX_DAG_DEPTH),
+                    1 + rng.nextInt(MAX_NODES_PER_LAYER),
+                    1 + rng.nextInt(MAX_PARENTS_PER_NODE),
+                    1 + rng.nextInt(MAX_TAGS_PER_NODE));
+        }
+
+        Set<String> getParents(final String nodeKey) {
+            return parentsMap.get(nodeKey);
+        }
+
+        /**
+         * Brute-force method
+         */
+        Set<String> getAncestors(final String nodeKey) {
+            final Set<String> parents = getParents(nodeKey);
+            return Sets.union(parents, parents.stream()
+                    .map(this::getAncestors)
+                    .flatMap(Set::stream)
+                    .collect(Collectors.toSet()));
+        }
+
+        /**
+         * Brute-force method
+         */
+        Set<String> getChildren(final String nodeKey) {
+            return nodeKeysSet.stream()
+                    .filter(key -> getParents(key).contains(nodeKey))
+                    .collect(Collectors.toSet());
+        }
+
+        /**
+         * Brute-force method
+         */
+        Set<String> getDescendents(final String nodeKey) {
+            final Set<String> children = getChildren(nodeKey);
+            return Sets.union(children, children.stream()
+                    .map(this::getDescendents)
+                    .flatMap(Set::stream)
+                    .collect(Collectors.toSet()));
+        }
+
+        Set<String> getInducedTags(final String nodeKey) {
+            final Set<String> allNodes = Sets.union(getDescendents(nodeKey), Collections.singleton(nodeKey));
+            return allNodes.stream()
+                    .map(tagsMap::get)
+                    .flatMap(Set::stream)
+                    .collect(Collectors.toSet());
+        }
+
+        List<String> getTopologicalOrderForNodeEvaluation(final String nodeKey) {
+            final List<String> sortedNodes = new ArrayList<>(Sets.union(getAncestors(nodeKey),
+                    Collections.singleton(nodeKey)));
+            sortedNodes.sort(Comparator.comparingInt(topologicalOrderMap::get));
+            return sortedNodes;
+        }
+
+        /**
+         * Brute-force method
+         */
+        List<String> getTopologicalOrderForNodeMutation(final String nodeKey) {
+            final Set<String> mutatedNodeAndDescendants = Sets.union(getDescendents(nodeKey),
+                    Collections.singleton(nodeKey));
+            final Set<String> ancestorsOfDescendants = getDescendents(nodeKey)
+                    .stream()
+                    .map(this::getAncestors)
+                    .flatMap(Set::stream)
+                    .collect(Collectors.toSet());
+            final Set<String> involvedNodes = Sets.union(mutatedNodeAndDescendants, ancestorsOfDescendants);
+            final List<String> topologicallySortedInvolvedNodes = new ArrayList<>(involvedNodes);
+            topologicallySortedInvolvedNodes.sort(Comparator.comparingInt(topologicalOrderMap::get));
+            return topologicallySortedInvolvedNodes;
+        }
+
+        /**
+         * Brute-force method
+         */
+        List<String> getTopologicalOrderForTagEvaluation(final String tag) {
+            final Set<String> taggedNodes = nodeKeysSet.stream()
+                    .filter(nodeKey -> getInducedTags(nodeKey).contains(tag))
+                    .collect(Collectors.toSet());
+            final Set<String> taggedNodesAndTheirAncestors = Sets.union(taggedNodes,
+                    taggedNodes.stream()
+                            .map(this::getAncestors)
+                            .flatMap(Set::stream)
+                            .collect(Collectors.toSet()));
+            final List<String> topologicallySortedtaggedNodesAndTheirAncestors = new ArrayList<>(taggedNodesAndTheirAncestors);
+            topologicallySortedtaggedNodesAndTheirAncestors.sort(Comparator.comparingInt(topologicalOrderMap::get));
+            return topologicallySortedtaggedNodesAndTheirAncestors;
+        }
+
+        Set<CacheNode> getEquivalentCacheNodeSet() {
+            final List<String> shuffledNodeList = new ArrayList<>(nodeKeysSet);
+            Collections.shuffle(shuffledNodeList, rng);
+            return shuffledNodeList.stream()
+                    .map(nodeKey -> topologicalOrderMap.get(nodeKey) == 0
+                            ? new PrimitiveCacheNode(nodeKey, tagsMap.get(nodeKey), null)
+                            : new ComputableCacheNode(nodeKey, tagsMap.get(nodeKey), getParents(nodeKey), null, true))
+                    .collect(Collectors.toSet());
+        }
+
+        private static Set<String> getRandomNodeKeys(final int maxNodes) {
+            return IntStream.range(0, rng.nextInt(maxNodes) + 1)
+                    .mapToObj(i -> "NODE_KEY_" + RandomStringUtils.randomAlphanumeric(NODE_KEY_LENGTH))
+                    .collect(Collectors.toSet());
+        }
+
+        private static Set<String> getRandomTags(final int maxTags) {
+            return IntStream.range(0, rng.nextInt(maxTags))
+                    .mapToObj(i -> "TAG_" + RandomStringUtils.randomAlphanumeric(TAG_LENGTH))
+                    .collect(Collectors.toSet());
+        }
+
+        private static String getRandomElement(final Set<String> set) {
+            final List<String> list = new ArrayList<>(set);
+            return list.get(rng.nextInt(list.size()));
+        }
+    }
+
+    private boolean isTopologicallyEquivalent(final List<String> actual, final List<String> expected,
+                                              final Map<String, Integer> topologicalOrderMap) {
+        if (actual == null || expected == null || !(new HashSet<>(actual).equals(new HashSet<>(expected)))) {
+            return false;
+        }
+        Utils.validateArg(topologicalOrderMap.keySet().containsAll(actual), "Some strings have unknown topological order");
+        return IntStream.range(0, expected.size()).allMatch(i ->
+                topologicalOrderMap.get(actual.get(i)).equals(topologicalOrderMap.get(expected.get(i))));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ImmutableComputableGraphUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ImmutableComputableGraphUnitTest.java
@@ -1,91 +1,1138 @@
 package org.broadinstitute.hellbender.tools.coveragemodel.cachemanager;
 
-import junit.framework.AssertionFailedError;
+import avro.shaded.com.google.common.collect.ImmutableMap;
+import avro.shaded.com.google.common.collect.Sets;
+import org.apache.commons.lang.RandomStringUtils;
+import org.broadinstitute.hellbender.utils.MathObjectAsserts;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.ops.transforms.Transforms;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Map;
+import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Unit tests for {@link ImmutableComputableGraph}
  *
- * TODO github/gatk-protected issue #803
+ * Most of the tests are done on the following, fairly generic, graph:
+ *
+ *     x    y    z
+ *     /\  / \  /
+ *     \ \/   \/
+ *      \ f   g
+ *       \ \  /
+ *        \ \/
+ *          h
+ *
+ *  x stores {@code DuplicableNDArray}
+ *  y stores {@code DuplicableNumber<Double>}
+ *  z stores {@code DuplicableNDArray}
+ *
+ *  f = f(x, y)
+ *  g = g(y, z)
+ *  h = h(f, g, x)
+ *
+ *  f, g, and h will be randomly composed from sine, cosine, identity, addition, subtraction, and
+ *  multiplication every time by calling {@link #generateNewRandomFunctionalComposition()}.
  *
  * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
  */
 public class ImmutableComputableGraphUnitTest extends BaseTest {
 
-    public static Function<Map<String, ? extends Duplicable>, ? extends Duplicable> func_0 = col -> {
-        final INDArray x = DuplicableNDArray.of(col.get("X"));
-        final double y = DuplicableNumber.of(col.get("Y"));
-        return new DuplicableNDArray(x.mul(y));
+    private static final Random rng = new Random(1984);
+
+    /**
+     * Number of trials for tests that involve random numbers
+     */
+    private static final int NUM_TRIALS = 5;
+
+    private static final Set<String> ALL_NODES = new HashSet<>(Arrays.asList("x", "y", "z", "f", "g", "h"));
+    private static final Set<String> ALL_PRIMITIVE_NODES = new HashSet<>(Arrays.asList("x", "y", "z"));
+    private static final Set<String> ALL_COMPUTABLE_NODES = new HashSet<>(Arrays.asList("f", "g", "h"));
+
+    /**
+     * A static counter to keep track of the number of function evaluations
+     */
+    private static final Counter counter = new Counter("f", "g", "h");
+
+    /**
+     * Shape of NDArrays in the ICG
+     */
+    private static final int[] TEST_NDARRAY_SHAPE = new int[] {2, 3};
+
+    private static final Function<INDArray, INDArray> UNARY_FUNCTION_COSINE = x -> Transforms.cos(x, true);
+    private static final Function<INDArray, INDArray> UNARY_FUNCTION_SINE = x -> Transforms.sin(x, true);
+    private static final Function<INDArray, INDArray> UNARY_FUNCTION_IDENTITY = x -> x;
+    private static final BiFunction<INDArray, INDArray, INDArray> BINARY_FUNCTION_ADD = INDArray::add;
+    private static final BiFunction<INDArray, INDArray, INDArray> BINARY_FUNCTION_SUB = INDArray::sub;
+    private static final BiFunction<INDArray, INDArray, INDArray> BINARY_FUNCTION_MUL = INDArray::mul;
+
+    private static final Map<String, BiFunction<INDArray, INDArray, INDArray>> TEST_BINARY_FUNCTIONS = ImmutableMap.of(
+            "add", BINARY_FUNCTION_ADD,
+            "sub", BINARY_FUNCTION_SUB,
+            "mul", BINARY_FUNCTION_MUL);
+
+    private static final Map<String, Function<INDArray, INDArray>> TEST_UNARY_FUNCTIONS = ImmutableMap.of(
+            "sin", UNARY_FUNCTION_SINE,
+            "cos", UNARY_FUNCTION_COSINE,
+            "id", UNARY_FUNCTION_IDENTITY);
+
+    private static final List<String> EMPTY_STRING_LIST = new ArrayList<>();
+    private static final Map<String, Duplicable> EMPTY_PARENTS = new HashMap<>();
+
+    /**
+     * Instructions for computing f(x, y) = F[2] ( F[0](x), F[1](x) )
+     *
+     * The first two strings describe one of the unary functions in {@link #TEST_UNARY_FUNCTIONS}
+     * The last string describes a binary function in {@link #TEST_BINARY_FUNCTIONS}
+     */
+    private static final List<String> F_COMPUTATION_INSTRUCTIONS = new ArrayList<>(Arrays.asList("id", "id", "add"));
+
+    /**
+     * Instructions for computing g(y, z) = F[2] ( F[0](y), F[1](z) )
+     *
+     * The first two strings describe one of the unary functions in {@link #TEST_UNARY_FUNCTIONS}
+     * The last string describes a binary function in {@link #TEST_BINARY_FUNCTIONS}
+     */
+    private static final List<String> G_COMPUTATION_INSTRUCTIONS = new ArrayList<>(Arrays.asList("id", "id", "mul"));
+
+    /**
+     * Instructions for computing h(f, g, x) = F[4]( F[3]( F[0](f), F[1](g) ), F[2](x) )
+     *
+     * The first three strings describe one of the unary functions in {@link #TEST_UNARY_FUNCTIONS}
+     * The last two strings describe one of the binary functions in {@link #TEST_BINARY_FUNCTIONS}
+     */
+    private static final List<String> H_COMPUTATION_INSTRUCTIONS = new ArrayList<>(Arrays.asList("id", "id", "id", "mul", "sub"));
+
+    /**
+     * Generates new functions for f, g, and h by updating {@link #F_COMPUTATION_INSTRUCTIONS},
+     * {@link #G_COMPUTATION_INSTRUCTIONS}, and {@link #H_COMPUTATION_INSTRUCTIONS}
+     */
+    private static void generateNewRandomFunctionalComposition() {
+        F_COMPUTATION_INSTRUCTIONS.clear();
+        F_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_UNARY_FUNCTIONS.keySet()));
+        F_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_UNARY_FUNCTIONS.keySet()));
+        F_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_BINARY_FUNCTIONS.keySet()));
+
+        G_COMPUTATION_INSTRUCTIONS.clear();
+        G_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_UNARY_FUNCTIONS.keySet()));
+        G_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_UNARY_FUNCTIONS.keySet()));
+        G_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_BINARY_FUNCTIONS.keySet()));
+
+        H_COMPUTATION_INSTRUCTIONS.clear();
+        H_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_UNARY_FUNCTIONS.keySet()));
+        H_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_UNARY_FUNCTIONS.keySet()));
+        H_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_UNARY_FUNCTIONS.keySet()));
+        H_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_BINARY_FUNCTIONS.keySet()));
+        H_COMPUTATION_INSTRUCTIONS.add(getRandomChoice(TEST_BINARY_FUNCTIONS.keySet()));
+    }
+
+    private static INDArray getRandomINDArray() {
+        return Nd4j.rand(TEST_NDARRAY_SHAPE);
+    }
+
+    private static double getRandomDouble() {
+        return rng.nextDouble();
+    }
+
+    private static <T> T getRandomChoice(final Set<T> collection) {
+        return getRandomChoice(new ArrayList<>(collection));
+    }
+
+    private static <T> T getRandomChoice(final List<T> collection) {
+        return collection.get(rng.nextInt(collection.size()));
+    }
+
+    private Set<String> getRandomSetOfTags() {
+        final int MAX_NUM_TAGS = 5;
+        final int TAG_LENGTH = 12;
+        return IntStream.range(0, rng.nextInt(MAX_NUM_TAGS))
+                .mapToObj(n -> RandomStringUtils.randomAlphanumeric(TAG_LENGTH))
+                .collect(Collectors.toSet());
+    }
+
+    private static Counter getCounterInstance() {
+        return counter.copy();
+    }
+
+    /**
+     * Computes "f" from "x" and "y" according to the instructions in {@link #F_COMPUTATION_INSTRUCTIONS}
+     */
+    private static INDArray f_computer(final INDArray x, final INDArray y) {
+        final INDArray xTrans = TEST_UNARY_FUNCTIONS.get(F_COMPUTATION_INSTRUCTIONS.get(0)).apply(x);
+        final INDArray yTrans = TEST_UNARY_FUNCTIONS.get(F_COMPUTATION_INSTRUCTIONS.get(1)).apply(y);
+        return TEST_BINARY_FUNCTIONS.get(F_COMPUTATION_INSTRUCTIONS.get(2)).apply(xTrans, yTrans);
+    }
+
+    /**
+     * Computes "g" from "y" and "z" according to the instructions in {@link #G_COMPUTATION_INSTRUCTIONS}
+     */
+    private static INDArray g_computer(final INDArray y, final INDArray z) {
+        final INDArray yTrans = TEST_UNARY_FUNCTIONS.get(G_COMPUTATION_INSTRUCTIONS.get(0)).apply(y);
+        final INDArray zTrans = TEST_UNARY_FUNCTIONS.get(G_COMPUTATION_INSTRUCTIONS.get(1)).apply(z);
+        return TEST_BINARY_FUNCTIONS.get(G_COMPUTATION_INSTRUCTIONS.get(2)).apply(yTrans, zTrans);
+    }
+
+    /**
+     * Computes "h" from "f", "g" and "x" according to the instructions in {@link #H_COMPUTATION_INSTRUCTIONS}
+     */
+    private static INDArray h_computer(final INDArray f, final INDArray g, final INDArray x) {
+        final INDArray fTrans = TEST_UNARY_FUNCTIONS.get(H_COMPUTATION_INSTRUCTIONS.get(0)).apply(f);
+        final INDArray gTrans = TEST_UNARY_FUNCTIONS.get(H_COMPUTATION_INSTRUCTIONS.get(1)).apply(g);
+        final INDArray xTrans = TEST_UNARY_FUNCTIONS.get(H_COMPUTATION_INSTRUCTIONS.get(2)).apply(x);
+        final INDArray fgResult = TEST_BINARY_FUNCTIONS.get(H_COMPUTATION_INSTRUCTIONS.get(3)).apply(fTrans, gTrans);
+        return TEST_BINARY_FUNCTIONS.get(H_COMPUTATION_INSTRUCTIONS.get(4)).apply(fgResult, xTrans);
+    }
+
+    /**
+     * An instance of {@link ComputableNodeFunction} for calculating f(x, y) automatically in the
+     * {@link ImmutableComputableGraph} representation of the problem. It computes "f" by calling
+     * {@link #f_computer(INDArray, INDArray)} and increments the static "f"-function evaluation counter.
+     */
+    private static ComputableNodeFunction f_computation_function = new ComputableNodeFunction() {
+        @Override
+        public Duplicable apply(Map<String, Duplicable> parents) throws ParentValueNotFoundException {
+            final INDArray x = fetchINDArray("x", parents);
+            final INDArray y = Nd4j.zeros(x.shape()).add(fetchDouble("y", parents));
+            final INDArray result = f_computer(x, y);
+            counter.increment("f");
+            return new DuplicableNDArray(result);
+        }
     };
 
-    public static Function<Map<String, ? extends Duplicable>, ? extends Duplicable> func_1 = col -> {
-        final INDArray xProdY = DuplicableNDArray.of(col.get("X_prod_Y"));
-        final double y = DuplicableNumber.of(col.get("Y"));
-        return new DuplicableNDArray(xProdY.add(y));
+    /**
+     * An instance of {@link ComputableNodeFunction} for calculating g(y, z) automatically in the
+     * {@link ImmutableComputableGraph} representation of the problem. It computes "g" by calling
+     * {@link #g_computer(INDArray, INDArray)} and increments the static "g"-function evaluation counter.
+     *
+     * Note: "y" will be casted into an {@link INDArray}
+     */
+    private static ComputableNodeFunction g_computation_function = new ComputableNodeFunction() {
+        @Override
+        public Duplicable apply(Map<String, Duplicable> parents) throws ParentValueNotFoundException {
+            final INDArray z = fetchINDArray("z", parents);
+            final INDArray y = Nd4j.zeros(z.shape()).add(fetchDouble("y", parents));
+            final INDArray result = g_computer(y, z);
+            counter.increment("g");
+            return new DuplicableNDArray(result);
+        }
     };
 
-    @Test(enabled = false)
-    public void testMissingParents() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    /**
+     * An instance of {@link ComputableNodeFunction} for calculating h(f, g, x) automatically in the
+     * {@link ImmutableComputableGraph} representation of the problem. It computes "h" by calling
+     * {@link #h_computer(INDArray, INDArray, INDArray)} and increments the static "h"-function evaluation
+     * counter.
+     */
+    public static ComputableNodeFunction h_computation_function = new ComputableNodeFunction() {
+        @Override
+        public Duplicable apply(Map<String, Duplicable> parents) throws ParentValueNotFoundException {
+            final INDArray f = fetchINDArray("f", parents);
+            final INDArray g = fetchINDArray("g", parents);
+            final INDArray x = fetchINDArray("x", parents);
+            final INDArray result = h_computer(f, g, x);
+            counter.increment("h");
+            return new DuplicableNDArray(result);
+        }
+    };
+
+    private static ImmutableComputableGraphUtils.ImmutableComputableGraphBuilder getTestICGBuilder(
+            final boolean f_caching, final boolean f_external,
+            final boolean g_caching, final boolean g_external,
+            final boolean h_caching, final boolean h_external,
+            final String[] x_tags, final String[] y_tags, final String[] z_tags,
+            final String[] f_tags, final String[] g_tags, final String[] h_tags) {
+        return ImmutableComputableGraph.builder()
+                .primitiveNode("x", x_tags, new DuplicableNDArray())
+                .primitiveNode("y", y_tags, new DuplicableNumber<Double>())
+                .primitiveNode("z", z_tags, new DuplicableNDArray())
+                .computableNode("f", f_tags, new String[]{"x", "y"},
+                        f_external ? null : f_computation_function, f_caching)
+                .computableNode("g", g_tags, new String[]{"y", "z"},
+                        g_external ? null : g_computation_function, g_caching)
+                .computableNode("h", h_tags, new String[]{"f", "g", "x"},
+                        h_external ? null : h_computation_function, h_caching);
     }
 
-    @Test(enabled = false)
-    public void testDuplicateNodeKeys() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    private static ImmutableComputableGraphUtils.ImmutableComputableGraphBuilder getTestICGBuilder(
+            final boolean f_caching, final boolean f_external,
+            final boolean g_caching, final boolean g_external,
+            final boolean h_caching, final boolean h_external) {
+        return getTestICGBuilder(f_caching, f_external, g_caching, g_external, h_caching, h_external,
+                new String[] {}, new String[] {}, new String[] {},
+                new String[] {}, new String[] {}, new String[] {});
     }
 
-    @Test(enabled = false)
-    public void testCyclicGraph() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    /**
+     * Calculates f, g, and h directly and asserts correctness
+     */
+    private static void assertCorrectness(final INDArray xExpected, final INDArray yExpected, final INDArray zExpected,
+                                          final INDArray xActual, final INDArray yActual, final INDArray zActual,
+                                          final INDArray fActual, final INDArray gActual, final INDArray hActual) {
+        final INDArray fExpected = f_computer(xExpected, yExpected);
+        final INDArray gExpected = g_computer(yExpected, zExpected);
+        final INDArray hExpected = h_computer(fExpected, gExpected, xExpected);
+        MathObjectAsserts.assertNDArrayEquals(xActual, xExpected);
+        MathObjectAsserts.assertNDArrayEquals(yActual, yExpected);
+        MathObjectAsserts.assertNDArrayEquals(zActual, zExpected);
+        MathObjectAsserts.assertNDArrayEquals(fActual, fExpected);
+        MathObjectAsserts.assertNDArrayEquals(gActual, gExpected);
+        MathObjectAsserts.assertNDArrayEquals(hActual, hExpected);
     }
 
-    @Test(enabled = false)
-    public void testOutdatedCaches() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    private boolean assertIntactReferences(@Nonnull final ImmutableComputableGraph original,
+                                           @Nonnull final ImmutableComputableGraph other,
+                                           @Nonnull final Set<String> unaffectedNodeKeys) {
+        final Set<String> affectedNodeKeys = unaffectedNodeKeys.stream()
+                .filter(nodeKey -> original.getCacheNode(nodeKey) != other.getCacheNode(nodeKey))
+                .collect(Collectors.toSet());
+        if (!affectedNodeKeys.isEmpty()) {
+            throw new AssertionError("Some of the node references have changed but they were supposed to remain" +
+                    " intact: " + affectedNodeKeys.stream().collect(Collectors.joining(", ")));
+        }
+        return true;
     }
 
-    @Test(enabled = false)
-    public void testUpToDateCaches() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    private boolean assertChangedReferences(@Nonnull final ImmutableComputableGraph original,
+                                            @Nonnull final ImmutableComputableGraph other,
+                                            @Nonnull final Set<String> affectedNodeKeys) {
+        final Set<String> unaffectedNodeKeys = affectedNodeKeys.stream()
+                .filter(nodeKey -> original.getCacheNode(nodeKey) == other.getCacheNode(nodeKey))
+                .collect(Collectors.toSet());
+        if (!unaffectedNodeKeys.isEmpty()) {
+            throw new AssertionError("Some of the node references have not changed but they were supposed to change: " +
+                    unaffectedNodeKeys.stream().collect(Collectors.joining(", ")));
+        }
+        return true;
     }
 
-    @Test(enabled = false)
-    public void testComputeOnDemandNodes() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    private boolean assertIntactReferences(@Nonnull final ImmutableComputableGraph original,
+                                           @Nonnull final ImmutableComputableGraph other,
+                                           @Nonnull final String... unaffectedNodeKeys) {
+        return assertIntactReferences(original, other, Arrays.stream(unaffectedNodeKeys).collect(Collectors.toSet()));
     }
 
-    @Test(enabled = false)
-    public void testPrimitiveUpdating() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    private boolean assertChangedReferences(@Nonnull final ImmutableComputableGraph original,
+                                            @Nonnull final ImmutableComputableGraph other,
+                                            @Nonnull final String... affectedNodeKeys) {
+        return assertChangedReferences(original, other, Arrays.stream(affectedNodeKeys).collect(Collectors.toSet()));
     }
 
-    @Test(enabled = false)
-    public void testExternallyComputableUpdating() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    /**
+     * Tests a fully automated auto-updating {@link ImmutableComputableGraph}
+     */
+    @Test(invocationCount = NUM_TRIALS)
+    public void testAutoUpdateCache() {
+        final ImmutableComputableGraph icg_0 = getTestICGBuilder(true, false, true, false, true, false)
+                .withCacheAutoUpdate().build();
+        generateNewRandomFunctionalComposition();
+        final INDArray x = getRandomINDArray();
+        final double y = getRandomDouble();
+        final INDArray z = getRandomINDArray();
+
+        Counter startCounts = getCounterInstance();
+        ImmutableComputableGraph icg_1 = icg_0
+                .setValue("x", new DuplicableNDArray(x))
+                .setValue("y", new DuplicableNumber<>(y))
+                .setValue("z", new DuplicableNDArray(z));
+        final INDArray xICG = (INDArray)icg_1.fetchDirectly("x").value();
+        final double yICG = (Double)icg_1.fetchDirectly("y").value();
+        final INDArray zICG = (INDArray)icg_1.fetchDirectly("z").value();
+        final INDArray fICG = (INDArray)icg_1.fetchDirectly("f").value();
+        final INDArray gICG = (INDArray)icg_1.fetchDirectly("g").value();
+        final INDArray hICG = (INDArray)icg_1.fetchDirectly("h").value();
+        Counter diffCounts = getCounterInstance().diff(startCounts);
+
+        assertCorrectness(x, Nd4j.zeros(TEST_NDARRAY_SHAPE).add(y), z,
+                xICG, Nd4j.zeros(TEST_NDARRAY_SHAPE).add(yICG), zICG,
+                fICG, gICG, hICG);
+
+        /* each function must be calculated only once; otherwise, ICG is doing redundant computations */
+        Assert.assertEquals(diffCounts.getCount("f"), 1);
+        Assert.assertEquals(diffCounts.getCount("g"), 1);
+        Assert.assertEquals(diffCounts.getCount("h"), 1);
+
+        /* if we update all caches again, nothing should change */
+        startCounts = getCounterInstance();
+        ImmutableComputableGraph icg_2 = icg_1.updateAllCaches();
+        diffCounts = getCounterInstance().diff(startCounts);
+        assertIntactReferences(icg_1, icg_2, ALL_NODES);
+        diffCounts.assertZero();
     }
 
-    @Test(enabled = false)
-    public void testCacheByTag() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    @DataProvider(name = "allPossibleNodeFlags")
+    public Object[][] getAllPossibleNodeFlags() {
+        final List<Object[]> data = new ArrayList<>();
+        for (final boolean f_caching : new boolean[] {true, false})
+            for (final boolean f_external : f_caching ? new boolean[] {true, false} : new boolean[] {false})
+                for (final boolean g_caching : new boolean[] {true, false})
+                    for (final boolean g_external : g_caching ? new boolean[] {true, false} : new boolean[] {false})
+                        for (final boolean h_caching : new boolean[] {true, false})
+                            for (final boolean h_external : h_caching ? new boolean[] {true, false} : new boolean[] {false})
+                                data.add(new Object[] {f_caching, f_external, g_caching, g_external, h_caching, h_external});
+        return data.toArray(new Object[data.size()][6]);
     }
 
-    @Test(enabled = false)
-    public void testCacheByNode() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    /**
+     * Tests bookkeeping of outdated nodes
+     */
+    @Test(dataProvider = "allPossibleNodeFlags", invocationCount = NUM_TRIALS)
+    public void testBookkeeping(final boolean f_caching, final boolean f_external,
+                                final boolean g_caching, final boolean g_external,
+                                final boolean h_caching, final boolean h_external) {
+        generateNewRandomFunctionalComposition();
+        final ImmutableComputableGraph icg_0 = getTestICGBuilder(f_caching, f_external, g_caching, g_external,
+                h_caching, h_external).build();
+
+        Assert.assertTrue(!icg_0.isValueDirectlyAvailable("x"));
+        Assert.assertTrue(!icg_0.isValueDirectlyAvailable("y"));
+        Assert.assertTrue(!icg_0.isValueDirectlyAvailable("z"));
+        Assert.assertTrue(!icg_0.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!icg_0.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_0.isValueDirectlyAvailable("h"));
+
+        ImmutableComputableGraph icg_tmp = icg_0;
+        icg_tmp = icg_tmp.setValue("x", new DuplicableNDArray(getRandomINDArray()));
+        Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("x"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("y"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("z"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("h"));
+        assertIntactReferences(icg_0, icg_tmp, "y", "z", "g");
+
+        ImmutableComputableGraph icg_tmp_old = icg_tmp;
+        icg_tmp = icg_tmp.setValue("y", new DuplicableNumber<>(getRandomDouble()));
+        Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("x"));
+        Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("y"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("z"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("h"));
+        assertIntactReferences(icg_tmp_old, icg_tmp, "x", "z");
+
+        icg_tmp_old = icg_tmp;
+        icg_tmp = icg_tmp.setValue("z", new DuplicableNDArray(getRandomINDArray()));
+        Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("x"));
+        Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("y"));
+        Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("z"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("h"));
+        assertIntactReferences(icg_tmp_old, icg_tmp, "x", "y", "f");
+
+        icg_tmp_old = icg_tmp;
+        try {
+            icg_tmp = icg_tmp.updateAllCaches();
+        } catch (final Exception ex) {
+            if (!f_external && !g_external && !h_external) {
+                throw new AssertionError("Could not update all caches but it should have been possible");
+            } else {
+                icg_tmp = icg_tmp.updateAllCachesIfPossible(); /* this will not throw exception by design */
+            }
+        }
+        assertIntactReferences(icg_tmp_old, icg_tmp, "x", "y", "z");
+
+        Assert.assertTrue((!f_caching && assertIntactReferences(icg_tmp_old, icg_tmp, "f")) ||
+                (f_external && !icg_tmp.isValueDirectlyAvailable("f") && assertIntactReferences(icg_tmp_old, icg_tmp, "f")) ||
+                (!f_external && icg_tmp.isValueDirectlyAvailable("f") && assertChangedReferences(icg_tmp_old, icg_tmp, "f")));
+
+        Assert.assertTrue((!g_caching && assertIntactReferences(icg_tmp_old, icg_tmp, "g")) ||
+                (g_external && !icg_tmp.isValueDirectlyAvailable("g") && assertIntactReferences(icg_tmp_old, icg_tmp, "g")) ||
+                (!g_external && icg_tmp.isValueDirectlyAvailable("g") && assertChangedReferences(icg_tmp_old, icg_tmp, "g")));
+
+        if (!f_external && !g_external) {
+            Assert.assertTrue((!h_caching && assertIntactReferences(icg_tmp_old, icg_tmp, "h")) ||
+                    (h_external && !icg_tmp.isValueDirectlyAvailable("h") && assertIntactReferences(icg_tmp_old, icg_tmp, "h")) ||
+                    (!h_external && icg_tmp.isValueDirectlyAvailable("h") && assertChangedReferences(icg_tmp_old, icg_tmp, "h")));
+        } else {
+            Assert.assertTrue(!icg_tmp.isValueDirectlyAvailable("h") && assertIntactReferences(icg_tmp_old, icg_tmp, "h"));
+        }
+
+        /* fill in the external values */
+        if (f_external) {
+            icg_tmp_old = icg_tmp;
+            icg_tmp = icg_tmp.setValue("f", f_computation_function.apply(
+                    ImmutableMap.of("x", icg_tmp.fetchDirectly("x"), "y", icg_tmp.fetchDirectly("y"))));
+            Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("f"));
+            assertIntactReferences(icg_tmp_old, icg_tmp, "x", "y", "z", "g");
+            assertChangedReferences(icg_tmp_old, icg_tmp, "f", "h");
+        }
+
+        if (g_external) {
+            icg_tmp_old = icg_tmp;
+            icg_tmp = icg_tmp.setValue("g", g_computation_function.apply(
+                    ImmutableMap.of("y", icg_tmp.fetchDirectly("y"), "z", icg_tmp.fetchDirectly("z"))));
+            Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("g"));
+            assertIntactReferences(icg_tmp_old, icg_tmp, "x", "y", "z", "f");
+            assertChangedReferences(icg_tmp_old, icg_tmp, "g", "h");
+        }
+
+        if (h_external) {
+            icg_tmp_old = icg_tmp;
+            icg_tmp = icg_tmp.setValue("h", h_computation_function.apply(ImmutableMap.of(
+                    "f", icg_tmp.fetchWithRequiredEvaluations("f"),
+                    "g", icg_tmp.fetchWithRequiredEvaluations("g"),
+                    "x", icg_tmp.fetchDirectly("x"))));
+            Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("h"));
+            assertIntactReferences(icg_tmp_old, icg_tmp, "x", "y", "z", "f", "g");
+            assertChangedReferences(icg_tmp_old, icg_tmp, "h");
+        }
+
+        /* since all externally computed nodes are initialized, a call to updateAllCaches() must succeed */
+        icg_tmp = icg_tmp.updateAllCaches();
+
+        /* at this point, every caching node must be up-to-date */
+        Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("x"));
+        Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("y"));
+        Assert.assertTrue(icg_tmp.isValueDirectlyAvailable("z"));
+        Assert.assertTrue(!f_caching || icg_tmp.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!g_caching || icg_tmp.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!h_caching || icg_tmp.isValueDirectlyAvailable("h"));
+
+        /* update x -- f and h must go out of date */
+        ImmutableComputableGraph icg_tmp_x = icg_tmp.setValue("x", new DuplicableNDArray(getRandomINDArray()));
+        Assert.assertTrue(!icg_tmp_x.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!g_caching || icg_tmp_x.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_tmp_x.isValueDirectlyAvailable("h"));
+
+        /* update y -- f, g and h must go out of date */
+        ImmutableComputableGraph icg_tmp_y = icg_tmp.setValue("y", new DuplicableNumber<>(getRandomDouble()));
+        Assert.assertTrue(!icg_tmp_y.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!icg_tmp_y.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_tmp_y.isValueDirectlyAvailable("h"));
+
+        /* update z -- g and h must go out of date */
+        ImmutableComputableGraph icg_tmp_z = icg_tmp.setValue("z", new DuplicableNDArray(getRandomINDArray()));
+        Assert.assertTrue(!f_caching || icg_tmp_z.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!icg_tmp_z.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_tmp_z.isValueDirectlyAvailable("h"));
+
+        /* update x and y -- f, g and h must go out of date */
+        ImmutableComputableGraph icg_tmp_xy = icg_tmp
+                .setValue("x", new DuplicableNDArray(getRandomINDArray()))
+                .setValue("y", new DuplicableNumber<>(getRandomDouble()));
+        Assert.assertTrue(!icg_tmp_xy.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!icg_tmp_xy.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_tmp_xy.isValueDirectlyAvailable("h"));
+
+        /* update x and z -- f, g and h must go out of date */
+        ImmutableComputableGraph icg_tmp_xz = icg_tmp
+                .setValue("x", new DuplicableNDArray(getRandomINDArray()))
+                .setValue("z", new DuplicableNDArray(getRandomINDArray()));
+        Assert.assertTrue(!icg_tmp_xz.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!icg_tmp_xz.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_tmp_xz.isValueDirectlyAvailable("h"));
+
+        /* update x and z -- f, g and h must go out of date */
+        ImmutableComputableGraph icg_tmp_xyz = icg_tmp
+                .setValue("x", new DuplicableNDArray(getRandomINDArray()))
+                .setValue("y", new DuplicableNumber<>(getRandomDouble()))
+                .setValue("z", new DuplicableNDArray(getRandomINDArray()));
+        Assert.assertTrue(!icg_tmp_xyz.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(!icg_tmp_xyz.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(!icg_tmp_xyz.isValueDirectlyAvailable("h"));
+
+        if (f_external) {
+            /* update f -- h must go out of date */
+            ImmutableComputableGraph icg_tmp_f = icg_tmp
+                    .setValue("f", new DuplicableNDArray(getRandomINDArray()));
+            Assert.assertTrue(!g_caching || icg_tmp_f.isValueDirectlyAvailable("g"));
+            Assert.assertTrue(!icg_tmp_f.isValueDirectlyAvailable("h"));
+        }
+
+        if (g_external) {
+            /* update g -- h must go out of date */
+            ImmutableComputableGraph icg_tmp_g = icg_tmp
+                    .setValue("g", new DuplicableNDArray(getRandomINDArray()));
+            Assert.assertTrue(!f_caching || icg_tmp_g.isValueDirectlyAvailable("f"));
+            Assert.assertTrue(!icg_tmp_g.isValueDirectlyAvailable("h"));
+        }
+
+        if (f_external && g_external) {
+            /* update f and g -- h must go out of date */
+            ImmutableComputableGraph icg_tmp_fg = icg_tmp
+                    .setValue("f", new DuplicableNDArray(getRandomINDArray()))
+                    .setValue("g", new DuplicableNDArray(getRandomINDArray()));
+            Assert.assertTrue(!icg_tmp_fg.isValueDirectlyAvailable("h"));
+        }
     }
 
-    @Test(enabled = false)
-    public void testCacheAutoUpdate() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    /**
+     * Tests propagation of tags from descendents to parents
+     */
+    @Test(dataProvider = "allPossibleNodeFlags", invocationCount = NUM_TRIALS)
+    public void testTagPropagation(final boolean f_caching, final boolean f_external,
+                                   final boolean g_caching, final boolean g_external,
+                                   final boolean h_caching, final boolean h_external) {
+        final Set<String> x_tags = getRandomSetOfTags();
+        final Set<String> y_tags = getRandomSetOfTags();
+        final Set<String> z_tags = getRandomSetOfTags();
+        final Set<String> f_tags = getRandomSetOfTags();
+        final Set<String> g_tags = getRandomSetOfTags();
+        final Set<String> h_tags = getRandomSetOfTags();
+        final ImmutableComputableGraph icg = getTestICGBuilder(
+                f_caching, f_external, g_caching, g_external, h_caching, h_external,
+                x_tags.toArray(new String[0]), y_tags.toArray(new String[0]),
+                z_tags.toArray(new String[0]), f_tags.toArray(new String[0]),
+                g_tags.toArray(new String[0]), h_tags.toArray(new String[0])).build();
+
+        final Set<String> all_x_tags = Sets.union(Sets.union(x_tags, f_tags), h_tags);
+        final Set<String> all_y_tags = Sets.union(Sets.union(Sets.union(y_tags, f_tags), g_tags), h_tags);
+        final Set<String> all_z_tags = Sets.union(Sets.union(z_tags, g_tags), h_tags);
+        final Set<String> all_f_tags = Sets.union(f_tags, h_tags);
+        final Set<String> all_g_tags = Sets.union(g_tags, h_tags);
+        final Set<String> all_h_tags = h_tags;
+
+        final Set<String> all_x_tags_actual = icg.getComputableGraphStructure().getInducedTagsForNode("x");
+        final Set<String> all_y_tags_actual = icg.getComputableGraphStructure().getInducedTagsForNode("y");
+        final Set<String> all_z_tags_actual = icg.getComputableGraphStructure().getInducedTagsForNode("z");
+        final Set<String> all_f_tags_actual = icg.getComputableGraphStructure().getInducedTagsForNode("f");
+        final Set<String> all_g_tags_actual = icg.getComputableGraphStructure().getInducedTagsForNode("g");
+        final Set<String> all_h_tags_actual = icg.getComputableGraphStructure().getInducedTagsForNode("h");
+
+        Assert.assertTrue(all_x_tags.equals(all_x_tags_actual));
+        Assert.assertTrue(all_y_tags.equals(all_y_tags_actual));
+        Assert.assertTrue(all_z_tags.equals(all_z_tags_actual));
+        Assert.assertTrue(all_f_tags.equals(all_f_tags_actual));
+        Assert.assertTrue(all_g_tags.equals(all_g_tags_actual));
+        Assert.assertTrue(all_h_tags.equals(all_h_tags_actual));
     }
 
-    @Test(enabled = false)
-    public void testUnchangedNodesSameReferenceAfterUpdate() {
-        throw new AssertionFailedError("Test is not implemented yet");
+    private Map<String, INDArray> getExpectedComputableNodeValues(final Duplicable x, final Duplicable y, final Duplicable z) {
+        final INDArray xVal = (INDArray)x.value();
+        final INDArray yVal = Nd4j.zeros(TEST_NDARRAY_SHAPE).add((Double)y.value());
+        final INDArray zVal = (INDArray)z.value();
+        final INDArray fExpected = f_computer(xVal, yVal);
+        final INDArray gExpected = g_computer(yVal, zVal);
+        final INDArray hExpected = h_computer(fExpected, gExpected, xVal);
+        return ImmutableMap.of("f", fExpected, "g", gExpected, "h", hExpected);
+    }
+
+    /**
+     * Tests {@link ImmutableComputableGraph#updateCachesForTag(String)}}
+     */
+    @Test(dataProvider = "allPossibleNodeFlags", invocationCount = NUM_TRIALS)
+    public void testUpdateCachesByTag(final boolean f_caching, final boolean f_external,
+                                      final boolean g_caching, final boolean g_external,
+                                      final boolean h_caching, final boolean h_external) {
+        generateNewRandomFunctionalComposition();
+        final ImmutableComputableGraph icg_empty = getTestICGBuilder(
+                f_caching, f_external, g_caching, g_external, h_caching, h_external,
+                getRandomSetOfTags().toArray(new String[0]), getRandomSetOfTags().toArray(new String[0]),
+                getRandomSetOfTags().toArray(new String[0]), getRandomSetOfTags().toArray(new String[0]),
+                getRandomSetOfTags().toArray(new String[0]), getRandomSetOfTags().toArray(new String[0])).build();
+
+        final Set<String> all_x_tags = icg_empty.getComputableGraphStructure().getInducedTagsForNode("x");
+        final Set<String> all_y_tags = icg_empty.getComputableGraphStructure().getInducedTagsForNode("y");
+        final Set<String> all_z_tags = icg_empty.getComputableGraphStructure().getInducedTagsForNode("z");
+        final Set<String> all_f_tags = icg_empty.getComputableGraphStructure().getInducedTagsForNode("f");
+        final Set<String> all_g_tags = icg_empty.getComputableGraphStructure().getInducedTagsForNode("g");
+        final Set<String> all_h_tags = icg_empty.getComputableGraphStructure().getInducedTagsForNode("h");
+        final Set<String> all_tags = new HashSet<>();
+        all_tags.addAll(all_x_tags); all_tags.addAll(all_y_tags); all_tags.addAll(all_z_tags);
+        all_tags.addAll(all_f_tags); all_tags.addAll(all_g_tags); all_tags.addAll(all_h_tags);
+
+        final INDArray x = getRandomINDArray();
+        final double y = getRandomDouble();
+        final INDArray z = getRandomINDArray();
+        final ImmutableComputableGraph icg_0 = icg_empty
+                .setValue("x", new DuplicableNDArray(x))
+                .setValue("y", new DuplicableNumber<>(y))
+                .setValue("z", new DuplicableNDArray(z));
+        final Map<String, INDArray> expectedComputableNodeValues = getExpectedComputableNodeValues(
+                icg_0.fetchDirectly("x"), icg_0.fetchDirectly("y"), icg_0.fetchDirectly("z"));
+
+        for (final String tag : all_tags) {
+            ImmutableComputableGraph icg_1;
+            Counter startCounter;
+            try {
+                startCounter = getCounterInstance();
+                icg_1 = icg_0.updateCachesForTag(tag);
+            } catch (final Exception ex) { /* should fail only if some of the tagged nodes are external */
+                if (!f_external && !g_external && !h_external) {
+                    throw new AssertionError("Could not update tagged nodes but it should have been possible");
+                }
+                /* perform a partial update and continue */
+                startCounter = getCounterInstance();
+                icg_1 = icg_0.updateCachesForTagIfPossible(tag);
+            }
+            final Counter evalCounts = getCounterInstance().diff(startCounter);
+
+            /* check updated caches */
+            final Set<String> updatedNodesExpected = new HashSet<>();
+            if (!f_external && f_caching && all_f_tags.contains(tag)) {
+                updatedNodesExpected.add("f");
+            }
+            if (!g_external && g_caching && all_g_tags.contains(tag)) {
+                updatedNodesExpected.add("g");
+            }
+            if (!h_external && !f_external && !g_external && h_caching && all_h_tags.contains(tag)) {
+                updatedNodesExpected.add("h");
+            }
+            assertChangedReferences(icg_0, icg_1, updatedNodesExpected);
+            assertIntactReferences(icg_0, icg_1, Sets.difference(ALL_NODES, updatedNodesExpected));
+
+            for (final String nodeKey : updatedNodesExpected) {
+                Assert.assertTrue(icg_1.isValueDirectlyAvailable(nodeKey));
+                MathObjectAsserts.assertNDArrayEquals((INDArray)icg_1.fetchDirectly(nodeKey).value(),
+                        expectedComputableNodeValues.get(nodeKey));
+            }
+            for (final String nodeKey : Sets.difference(ALL_COMPUTABLE_NODES, updatedNodesExpected)) {
+                Assert.assertTrue(!icg_1.isValueDirectlyAvailable(nodeKey));
+            }
+
+            /* check function evaluation counts */
+            if ((!f_external && all_f_tags.contains(tag)) /* f is computable and caching */ ||
+                    (all_h_tags.contains(tag) && !f_external && !g_external && !h_external) /* h, as a descendant, is computable */) {
+                Assert.assertEquals(evalCounts.getCount("f"), 1);
+            } else {
+                Assert.assertEquals(evalCounts.getCount("f"), 0);
+            }
+            if ((!g_external && all_g_tags.contains(tag)) /* g is computable and caching */ ||
+                    (all_h_tags.contains(tag) && !g_external && !f_external && !h_external) /* h, as a descendant, is computable */) {
+                Assert.assertEquals(evalCounts.getCount("g"), 1);
+            } else {
+                Assert.assertEquals(evalCounts.getCount("g"), 0);
+            }
+            if (all_h_tags.contains(tag) && !f_external && !g_external && !h_external) {
+                Assert.assertEquals(evalCounts.getCount("h"), 1);
+            } else {
+                Assert.assertEquals(evalCounts.getCount("h"), 0);
+            }
+        }
+    }
+
+    /**
+     * Tests {@link ImmutableComputableGraph#updateCachesForNode(String)}}
+     */
+    @Test(dataProvider = "allPossibleNodeFlags", invocationCount = NUM_TRIALS)
+    public void testUpdateCacheByNode(final boolean f_caching, final boolean f_external,
+                                      final boolean g_caching, final boolean g_external,
+                                      final boolean h_caching, final boolean h_external) {
+        generateNewRandomFunctionalComposition();
+        final ImmutableComputableGraph icg_empty = getTestICGBuilder(
+                f_caching, f_external, g_caching, g_external, h_caching, h_external).build();
+
+        final INDArray x = getRandomINDArray();
+        final double y = getRandomDouble();
+        final INDArray z = getRandomINDArray();
+        final ImmutableComputableGraph icg_0 = icg_empty
+                .setValue("x", new DuplicableNDArray(x))
+                .setValue("y", new DuplicableNumber<>(y))
+                .setValue("z", new DuplicableNDArray(z));
+        final Map<String, INDArray> expectedComputableNodeValues = getExpectedComputableNodeValues(
+                icg_0.fetchDirectly("x"), icg_0.fetchDirectly("y"), icg_0.fetchDirectly("z"));
+
+        for (final String nodeKey : ALL_PRIMITIVE_NODES) {
+            Counter startCounter = getCounterInstance();
+            ImmutableComputableGraph icg_1 = icg_0.updateCachesForNode(nodeKey);
+            final Counter evalCounts = getCounterInstance().diff(startCounter);
+            assertIntactReferences(icg_0, icg_1, ALL_NODES);
+            evalCounts.assertZero();
+        }
+
+        ImmutableComputableGraph icg_1;
+        Counter startCounter;
+        Counter diff;
+
+        /* tests for "f" */
+        try {
+            startCounter = getCounterInstance();
+            icg_1 = icg_0.updateCachesForNode("f");
+        } catch (final Exception ex) { /* should fail only if some of the tagged nodes are external */
+            if (!f_external && !g_external && !h_external) {
+                throw new AssertionError("Could not update tagged nodes but it should have been possible");
+            }
+            startCounter = getCounterInstance();
+            icg_1 = icg_0.updateCachesForNodeIfPossible("f");
+        }
+        diff = getCounterInstance().diff(startCounter);
+
+        assertIntactReferences(icg_0, icg_1, "x", "y", "z", "g");
+        if (f_external) {
+            assertIntactReferences(icg_0, icg_1, ALL_NODES);
+            diff.assertZero();
+        } else {
+            Assert.assertEquals(diff.getCount("f"), 1);
+            Assert.assertEquals(diff.getCount("g"), 0);
+            Assert.assertEquals(diff.getCount("h"), 0);
+            if (f_caching) {
+                Assert.assertTrue(icg_1.isValueDirectlyAvailable("f"));
+                MathObjectAsserts.assertNDArrayEquals((INDArray)icg_1.fetchDirectly("f").value(),
+                        expectedComputableNodeValues.get("f"));
+            } else {
+                final Counter before = getCounterInstance();
+                Assert.assertTrue(!icg_1.isValueDirectlyAvailable("f"));
+                MathObjectAsserts.assertNDArrayEquals((INDArray)icg_1.fetchWithRequiredEvaluations("f").value(),
+                        expectedComputableNodeValues.get("f"));
+                final Counter diff2 = getCounterInstance().diff(before);
+                Assert.assertEquals(diff2.getCount("f"), 1);
+                Assert.assertEquals(diff2.getCount("g"), 0);
+                Assert.assertEquals(diff2.getCount("h"), 0);
+            }
+        }
+
+        /* tests for "g" */
+        try {
+            startCounter = getCounterInstance();
+            icg_1 = icg_0.updateCachesForNode("g");
+        } catch (final Exception ex) { /* should fail only if some of the tagged nodes are external */
+            if (!f_external && !g_external && !h_external) {
+                throw new AssertionError("Could not update tagged nodes but it should have been possible");
+            }
+            startCounter = getCounterInstance();
+            icg_1 = icg_0.updateCachesForNodeIfPossible("g");
+        }
+        diff = getCounterInstance().diff(startCounter);
+
+        assertIntactReferences(icg_0, icg_1, "x", "y", "z", "f");
+        if (g_external) {
+            assertIntactReferences(icg_0, icg_1, ALL_NODES);
+            diff.assertZero();
+        } else {
+            Assert.assertEquals(diff.getCount("f"), 0);
+            Assert.assertEquals(diff.getCount("g"), 1);
+            Assert.assertEquals(diff.getCount("h"), 0);
+            if (g_caching) {
+                Assert.assertTrue(icg_1.isValueDirectlyAvailable("g"));
+                MathObjectAsserts.assertNDArrayEquals((INDArray)icg_1.fetchDirectly("g").value(),
+                        expectedComputableNodeValues.get("g"));
+            } else {
+                Assert.assertTrue(!icg_1.isValueDirectlyAvailable("g"));
+                final Counter before = getCounterInstance();
+                MathObjectAsserts.assertNDArrayEquals((INDArray)icg_1.fetchWithRequiredEvaluations("g").value(),
+                        expectedComputableNodeValues.get("g"));
+                final Counter diff2 = getCounterInstance().diff(before);
+                Assert.assertEquals(diff2.getCount("f"), 0);
+                Assert.assertEquals(diff2.getCount("g"), 1);
+                Assert.assertEquals(diff2.getCount("h"), 0);
+            }
+        }
+
+        /* tests for "h" */
+        try {
+            startCounter = getCounterInstance();
+            icg_1 = icg_0.updateCachesForNode("h");
+        } catch (final Exception ex) { /* should fail only if some of the tagged nodes are external */
+            if (!f_external && !g_external && !h_external) {
+                throw new AssertionError("Could not update tagged nodes but it should have been possible");
+            }
+            startCounter = getCounterInstance();
+            icg_1 = icg_0.updateCachesForNodeIfPossible("h");
+        }
+        diff = getCounterInstance().diff(startCounter);
+        assertIntactReferences(icg_0, icg_1, "x", "y", "z");
+        if (h_external && f_external && g_external) {
+            assertIntactReferences(icg_0, icg_1, ALL_NODES);
+            diff.assertZero();
+        } else if (!h_external && !f_external && !g_external) {
+            Assert.assertEquals(diff.getCount("f"), 1);
+            Assert.assertEquals(diff.getCount("g"), 1);
+            Assert.assertEquals(diff.getCount("h"), 1);
+            if (h_caching) {
+                Assert.assertTrue(icg_1.isValueDirectlyAvailable("h"));
+                MathObjectAsserts.assertNDArrayEquals(
+                        (INDArray)icg_1.fetchDirectly("h").value(),
+                        expectedComputableNodeValues.get("h"));
+            } else {
+                Assert.assertTrue(!icg_1.isValueDirectlyAvailable("h"));
+                final Counter before = getCounterInstance();
+                MathObjectAsserts.assertNDArrayEquals(
+                        (INDArray)icg_1.fetchWithRequiredEvaluations("h").value(),
+                        expectedComputableNodeValues.get("h"));
+                final Counter diff2 = getCounterInstance().diff(before);
+                Assert.assertEquals(diff2.getCount("f"), f_caching ? 0 : 1);
+                Assert.assertEquals(diff2.getCount("g"), g_caching ? 0 : 1);
+                Assert.assertEquals(diff2.getCount("h"), 1);
+            }
+        }
+    }
+
+    @Test
+    public void testUninitializedPrimitiveNode() {
+        final ImmutableComputableGraph icg = getTestICGBuilder(true, false, true, false, true, false).build()
+                .setValue("x", new DuplicableNDArray(getRandomINDArray()))
+                .setValue("y", new DuplicableNumber<>(getRandomDouble()));
+        boolean failed = false;
+        try {
+            icg.updateAllCaches();
+        } catch (final PrimitiveCacheNode.PrimitiveValueNotInitializedException ex) {
+            failed = true;
+        }
+        if (!failed) {
+            throw new AssertionError("Expected PrimitiveValueNotInitializedException but it was not thrown");
+        }
+
+        icg.updateCachesForNode("f"); /* should not fail */
+
+        failed = false;
+        try {
+            icg.updateCachesForNode("g");
+        } catch (final PrimitiveCacheNode.PrimitiveValueNotInitializedException ex) {
+            failed = true;
+        }
+        if (!failed) {
+            throw new AssertionError("Expected PrimitiveValueNotInitializedException but it was not thrown");
+        }
+
+        failed = false;
+        try {
+            icg.updateCachesForNode("h");
+        } catch (final PrimitiveCacheNode.PrimitiveValueNotInitializedException ex) {
+            failed = true;
+        }
+        if (!failed) {
+            throw new AssertionError("Expected PrimitiveValueNotInitializedException but it was not thrown");
+        }
+    }
+
+    @Test
+    public void testExternallyComputedNode() {
+        final ImmutableComputableGraph icg = getTestICGBuilder(true, true, true, false, true, false).build()
+                .setValue("x", new DuplicableNDArray(getRandomINDArray()))
+                .setValue("y", new DuplicableNumber<>(getRandomDouble()))
+                .setValue("z", new DuplicableNDArray(getRandomINDArray()));
+        boolean failed = false;
+        try {
+            icg.updateAllCaches();
+        } catch (final ComputableCacheNode.ExternallyComputableNodeValueUnavailableException ex) {
+            failed = true;
+        }
+        if (!failed) {
+            throw new AssertionError("Expected ExternallyComputableNodeValueUnavailableException but it was not thrown");
+        }
+
+        icg.updateCachesForNode("g"); /* should not fail */
+
+        failed = false;
+        try {
+            icg.updateCachesForNode("f");
+        } catch (final ComputableCacheNode.ExternallyComputableNodeValueUnavailableException ex) {
+            failed = true;
+        }
+        if (!failed) {
+            throw new AssertionError("Expected ExternallyComputableNodeValueUnavailableException but it was not thrown");
+        }
+
+        failed = false;
+        try {
+            icg.updateCachesForNode("h");
+        } catch (final ComputableCacheNode.ExternallyComputableNodeValueUnavailableException ex) {
+            failed = true;
+        }
+        if (!failed) {
+            throw new AssertionError("Expected ExternallyComputableNodeValueUnavailableException but it was not thrown");
+        }
+
+        /* supply f */
+        ImmutableComputableGraph icg_1 = icg.setValue("f", f_computation_function.apply(
+                ImmutableMap.of("x", icg.fetchDirectly("x"), "y", icg.fetchDirectly("y"))));
+        Assert.assertTrue(icg_1.isValueDirectlyAvailable("f"));
+
+        /* cache g */
+        Assert.assertTrue(!icg_1.isValueDirectlyAvailable("g"));
+        Counter before = getCounterInstance();
+        icg_1 = icg_1.updateCachesForNode("g");
+        Assert.assertTrue(icg_1.isValueDirectlyAvailable("g"));
+        Counter diff = getCounterInstance().diff(before);
+        Assert.assertEquals(diff.getCount("f"), 0);
+        Assert.assertEquals(diff.getCount("g"), 1);
+        Assert.assertEquals(diff.getCount("h"), 0);
+
+        /* cache h -- now, it is computable */
+        Assert.assertTrue(!icg_1.isValueDirectlyAvailable("h"));
+        before = getCounterInstance();
+        icg_1 = icg_1.updateCachesForNode("h");
+        Assert.assertTrue(icg_1.isValueDirectlyAvailable("h"));
+        diff = getCounterInstance().diff(before);
+        Assert.assertEquals(diff.getCount("f"), 0);
+        Assert.assertEquals(diff.getCount("g"), 0);
+        Assert.assertEquals(diff.getCount("h"), 1);
+
+        /* updating all caches must have no effect */
+        before = getCounterInstance();
+        ImmutableComputableGraph icg_2 = icg_1.updateAllCaches();
+        getCounterInstance().diff(before).assertZero();
+        Assert.assertTrue(icg_2.isValueDirectlyAvailable("f"));
+        Assert.assertTrue(icg_2.isValueDirectlyAvailable("g"));
+        Assert.assertTrue(icg_2.isValueDirectlyAvailable("h"));
+        assertIntactReferences(icg_1, icg_2, ALL_NODES);
+    }
+
+    /**
+     * Asserts that the equality comparison of two {@link CacheNode}s is done just based on their key
+     */
+    @Test
+    public void testEquality() {
+        final List<CacheNode> nodesWithOneKey = getRandomCollectionOfNodesWithTheSameKey("ONE_KEY");
+        final List<CacheNode> nodesWithAnotherKey = getRandomCollectionOfNodesWithTheSameKey("ANOTHER_KEY");
+
+        for (final CacheNode node_0 : nodesWithOneKey) {
+            for (final CacheNode node_1 : nodesWithOneKey) {
+                Assert.assertTrue(node_0.equals(node_1) || (node_0.getClass() != node_1.getClass()));
+            }
+        }
+
+        for (final CacheNode node_0 : nodesWithAnotherKey) {
+            for (final CacheNode node_1 : nodesWithAnotherKey) {
+                Assert.assertTrue(node_0.equals(node_1) || (node_0.getClass() != node_1.getClass()));
+            }
+        }
+
+        for (final CacheNode node_0 : nodesWithOneKey) {
+            for (final CacheNode node_1 : nodesWithAnotherKey) {
+                Assert.assertTrue(!node_0.equals(node_1));
+            }
+        }
+    }
+
+    @Test
+    public void testToString() {
+        final List<CacheNode> nodesWithOneKey = getRandomCollectionOfNodesWithTheSameKey("ONE_KEY");
+        for (final CacheNode node : nodesWithOneKey) {
+            Assert.assertTrue(node.toString().equals("ONE_KEY"));
+        }
+    }
+
+    private List<CacheNode> getRandomCollectionOfNodesWithTheSameKey(final String key) {
+        final List<CacheNode> collection = new ArrayList<>();
+        collection.add(new PrimitiveCacheNode(key, EMPTY_STRING_LIST, null));
+        collection.add(new PrimitiveCacheNode(key, Arrays.asList("a", "b", "c"), new DuplicableNumber<>(1.0)));
+        collection.add(new ComputableCacheNode(key, EMPTY_STRING_LIST, Arrays.asList("d", "e"),
+                f_computation_function, false));
+        collection.add(new ComputableCacheNode(key, EMPTY_STRING_LIST, EMPTY_STRING_LIST,
+                f_computation_function, false));
+        collection.add(new ComputableCacheNode(key, Arrays.asList("f"), Arrays.asList("g"), null, true));
+        return collection;
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testSetValueOfAutomaticallyComputableNode() {
+        new ComputableCacheNode("TEST", EMPTY_STRING_LIST, EMPTY_STRING_LIST, h_computation_function, false)
+                .set(new DuplicableNDArray(getRandomINDArray()));
+    }
+
+    @Test
+    public void testSetValueOfExternallyComputableNode() {
+        final ComputableCacheNode node = new ComputableCacheNode("TEST", EMPTY_STRING_LIST, EMPTY_STRING_LIST, null, true);
+        final INDArray arr = getRandomINDArray();
+        node.set(new DuplicableNDArray(arr));
+        MathObjectAsserts.assertNDArrayEquals((INDArray)node.get(EMPTY_PARENTS).value(), arr);
+    }
+
+    @Test
+    public void testSetValueOfPrimitiveNode() {
+        final PrimitiveCacheNode node = new PrimitiveCacheNode("TEST", EMPTY_STRING_LIST, null);
+        final INDArray arr = getRandomINDArray();
+        node.set(new DuplicableNDArray(arr));
+        MathObjectAsserts.assertNDArrayEquals((INDArray)node.get(EMPTY_PARENTS).value(), arr);
+    }
+
+    @Test
+    public void testPrimitiveNodeDuplication() {
+        final PrimitiveCacheNode node = new PrimitiveCacheNode("TEST", EMPTY_STRING_LIST,
+                new DuplicableNDArray(getRandomINDArray()));
+        final PrimitiveCacheNode dupNode = node.duplicate();
+        MathObjectAsserts.assertNDArrayEquals((INDArray)node.get(EMPTY_PARENTS).value(),
+                (INDArray)dupNode.get(EMPTY_PARENTS).value());
+        Assert.assertTrue(dupNode.hasValue());
+        Assert.assertTrue(dupNode.getKey().equals("TEST"));
+    }
+
+    @Test
+    public void testCachingComputableNodeDuplication() {
+        final INDArray testArray = getRandomINDArray();
+        final Duplicable testDuplicable = new DuplicableNDArray(testArray);
+        final ComputableNodeFunction trivialFunction = parents -> testDuplicable;
+
+        final ComputableCacheNode cachingAutoNodeUncached = new ComputableCacheNode("TEST", EMPTY_STRING_LIST,
+                EMPTY_STRING_LIST, trivialFunction, true);
+        final ComputableCacheNode cachingAutoNodeUncachedDup = cachingAutoNodeUncached.duplicate();
+
+        final ComputableCacheNode cachingAutoNodeCached = cachingAutoNodeUncached.duplicateWithUpdatedValue(testDuplicable);
+        final ComputableCacheNode cachingAutoNodeCachedDup = cachingAutoNodeCached.duplicate();
+
+        final ComputableCacheNode cachingAutoNodeCachedOutdated = cachingAutoNodeCached.duplicateWithOutdatedCacheStatus();
+        final ComputableCacheNode cachingAutoNodeCachedOutdatedDup = cachingAutoNodeCachedOutdated.duplicate();
+
+        Assert.assertTrue(cachingAutoNodeUncached.isCaching());
+        Assert.assertTrue(cachingAutoNodeUncachedDup.isCaching());
+        Assert.assertTrue(!cachingAutoNodeUncached.isExternallyComputed());
+        Assert.assertTrue(!cachingAutoNodeUncachedDup.isExternallyComputed());
+        Assert.assertTrue(!cachingAutoNodeUncached.hasValue());
+        Assert.assertTrue(!cachingAutoNodeUncachedDup.hasValue());
+
+        Assert.assertTrue(cachingAutoNodeCached.isCaching());
+        Assert.assertTrue(cachingAutoNodeCachedDup.isCaching());
+        Assert.assertTrue(!cachingAutoNodeCached.isExternallyComputed());
+        Assert.assertTrue(!cachingAutoNodeCachedDup.isExternallyComputed());
+        Assert.assertTrue(cachingAutoNodeCached.hasValue());
+        Assert.assertTrue(cachingAutoNodeCachedDup.hasValue());
+        MathObjectAsserts.assertNDArrayEquals((INDArray)cachingAutoNodeCached.get(EMPTY_PARENTS).value(),
+                (INDArray)cachingAutoNodeCachedDup.get(EMPTY_PARENTS).value());
+
+        Assert.assertTrue(cachingAutoNodeCachedOutdated.isCaching());
+        Assert.assertTrue(cachingAutoNodeCachedOutdatedDup.isCaching());
+        Assert.assertTrue(!cachingAutoNodeCachedOutdated.isExternallyComputed());
+        Assert.assertTrue(!cachingAutoNodeCachedOutdatedDup.isExternallyComputed());
+        Assert.assertTrue(!cachingAutoNodeCachedOutdated.hasValue()); /* outdated caches must drop out */
+        Assert.assertTrue(!cachingAutoNodeCachedOutdatedDup.hasValue()); /* outdated caches must drop out */
+    }
+
+    /**
+     * A simple helper class for keeping track of ICG function evaluations
+     */
+    private static class Counter {
+        final Map<String, Integer> counts;
+
+        Counter(String ... keys) {
+            counts = new HashMap<>();
+            for (final String key : keys) {
+                counts.put(key, 0);
+            }
+        }
+
+        private Counter(final Map<String, Integer> otherCounts) {
+            counts = new HashMap<>(otherCounts.size());
+            counts.putAll(otherCounts);
+        }
+
+        void increment(final String key) {
+            counts.put(key, getCount(key) + 1);
+        }
+
+        int getCount(final String key) {
+            return counts.get(key);
+        }
+
+        Set<String> getKeys() {
+            return counts.keySet();
+        }
+
+        Counter copy() {
+            return new Counter(counts);
+        }
+
+        Counter diff(final Counter oldCounter) {
+            Utils.validateArg(Sets.symmetricDifference(oldCounter.getKeys(), getKeys()).isEmpty(),
+                    "the counters must have the same keys");
+            final Map<String, Integer> diffMap = new HashMap<>(getKeys().size());
+            getKeys().forEach(key -> diffMap.put(key, getCount(key) - oldCounter.getCount(key)));
+            return new Counter(diffMap);
+        }
+
+        void assertZero() {
+            Assert.assertTrue(counts.values().stream().allMatch(val -> val == 0));
+        }
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ImmutableComputableGraphUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/coveragemodel/cachemanager/ImmutableComputableGraphUtilsUnitTest.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.hellbender.tools.coveragemodel.cachemanager;
+
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link ImmutableComputableGraphUtils}.
+ *
+ * @author Mehrtash Babadi &lt;mehrtash@broadinstitute.org&gt;
+ */
+public class ImmutableComputableGraphUtilsUnitTest extends BaseTest {
+
+    @Test(expectedExceptions = ImmutableComputableGraphUtils.ImmutableComputableGraphBuilder.DuplicateNodeKeyException.class)
+    public void testDuplicatePrimitiveNode() {
+        ImmutableComputableGraph.builder()
+                .primitiveNode("x", new String[] {}, new DuplicableNDArray())
+                .primitiveNode("x", new String[] {}, new DuplicableNDArray())
+                .build();
+    }
+
+    @Test(expectedExceptions = ImmutableComputableGraphUtils.ImmutableComputableGraphBuilder.DuplicateNodeKeyException.class)
+    public void testDuplicateComputableNode() {
+        ImmutableComputableGraph.builder()
+                .computableNode("x", new String[] {}, new String[] {}, null, true)
+                .computableNode("x", new String[] {}, new String[] {}, null, true)
+                .build();
+    }
+}


### PR DESCRIPTION
- reviewed and restricted the access modifiers of all ICG-related classes
- got rid of the functionality to hold on to old caches: whenever a cache goes out of date, the reference is immediately made null in the new ICG
- completely rewrote ComputableGraphStructure in a functional style
- got rid of unused and unnecessary methods
- Created an ImmutableComputableGraphUtils and factored out the builder and other common methods
- math equality asserts for NDArray
- unit tests for ComputableGraphStructure
- unit tests for ImmutableComputableGraph
- unit tests for ImmutableComputableGraphUtils