### PR TITLE
CNV CalculateTargetCoverage: tag doc; example WES command; change defaults

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
@@ -47,13 +47,13 @@ import java.util.stream.IntStream;
  *
  * <pre>
  * java -Xmx4g -jar $gatk_jar CalculateTargetCoverage \
- *   --input bam.bam \
+ *   --input sample.bam \
  *   --targets padded_targets.tsv \
  *   --groupBy SAMPLE \
  *   --transform PCOV \
  *   --targetInformationColumns FULL \
  *   --disableReadFilter NotDuplicateReadFilter \
- *   --output base_filename.coverage.tsv
+ *   --output sample.coverage.tsv
  * </pre>
  *
  * <p>

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
@@ -58,11 +58,11 @@ import java.util.stream.IntStream;
  *
  * <p>
  *     The interval targets are exome target intervals padded, e.g. with 250 bases on either side.
- *     Target intervals do NOT overlap. Use the PadTargets tool to generate non-overlapping padded intervals from exome targets.
+ *     Target intervals do NOT overlap. Use the {@link PadTargets} tool to generate non-overlapping padded intervals from exome targets.
  *     Do NOT use BED format. See {@link ConvertBedToTargetFile}.
  * </p>
  *
- * <p>For whole genome sequencing (WGS) data, use SparkGenomeReadCounts instead.</p>
+ * <p>For whole genome sequencing (WGS) data, use {@link SparkGenomeReadCounts} instead.</p>
  *
  */
 @CommandLineProgramProperties(

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
@@ -49,6 +49,9 @@ import java.util.stream.IntStream;
  * java -Xmx4g -jar $gatk_jar CalculateTargetCoverage \
  *   --input bam.bam \
  *   --targets padded_targets.tsv \
+ *   --groupBy SAMPLE \
+ *   --transform PCOV \
+ *   --targetInformationColumns FULL \
  *   --disableReadFilter NotDuplicateReadFilter \
  *   --output base_filename.coverage.tsv
  * </pre>
@@ -134,7 +137,7 @@ public final class CalculateTargetCoverage extends ReadWalker {
             shortName = GROUP_BY_SHORT_NAME,
             fullName = GROUP_BY_FULL_NAME,
             optional = true)
-    protected GroupBy groupBy = GroupBy.SAMPLE;
+    protected GroupBy groupBy = GroupBy.COHORT;
 
     @Argument(
             doc = "Cohort name used to name the read count column when the groupBy " +
@@ -151,7 +154,7 @@ public final class CalculateTargetCoverage extends ReadWalker {
             fullName = TRANSFORM_FULL_NAME,
             optional = true
     )
-    protected Transform transform = Transform.PCOV;
+    protected Transform transform = Transform.RAW;
 
     @Argument(
             doc = "TSV file listing 1-based genomic intervals with specific column headers. Do NOT use BED format.",
@@ -167,7 +170,7 @@ public final class CalculateTargetCoverage extends ReadWalker {
             fullName = TARGET_OUT_INFO_FULL_NAME,
             optional = true
     )
-    protected TargetOutInfo targetOutInfo = TargetOutInfo.FULL;
+    protected TargetOutInfo targetOutInfo = TargetOutInfo.COORDS;
 
     /**
      * Writer to the main output file indicated by {@link #output}.
@@ -693,7 +696,7 @@ public final class CalculateTargetCoverage extends ReadWalker {
         RAW((count, columnTotal) -> Integer.toString(count)),
 
         /**
-         * Default proportional coverage transformation.
+         * Proportional coverage transformation.
          * <p>Individual counts are transformed into the fraction of the total
          * count across the enclosing column.</p>
          */

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * Calculate read-counts across targets given their reference coordinates.
+ * Calculates read-counts across targets for the exome copy number variant (CNV) calling workflow.
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  *
@@ -59,7 +59,7 @@ import java.util.stream.IntStream;
  * <p>
  *     The interval targets are exome target intervals padded, e.g. with 250 bases on either side.
  *     Target intervals do NOT overlap. Use the PadTargets tool to generate non-overlapping padded intervals from exome targets.
- *     Do NOT use BED format. See ConvertBedToTargetFile.
+ *     Do NOT use BED format. See {@link ConvertBedToTargetFile}.
  * </p>
  *
  * <p>For whole genome sequencing (WGS) data, use SparkGenomeReadCounts instead.</p>

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
@@ -140,8 +140,7 @@ public final class CalculateTargetCoverage extends ReadWalker {
     protected GroupBy groupBy = GroupBy.COHORT;
 
     @Argument(
-            doc = "Cohort name used to name the read count column when the groupBy " +
-                    "argument is set to COHORT",
+            doc = "Cohort name used to name the read count column when the groupBy argument is set to COHORT",
             shortName = COHORT_SHORT_NAME,
             fullName = COHORT_FULL_NAME,
             optional = true)
@@ -691,7 +690,7 @@ public final class CalculateTargetCoverage extends ReadWalker {
     protected enum Transform {
 
         /**
-         * Read-count raw value (non-)transformation.
+         * Raw integer read-count (non-)transformation.
          */
         RAW((count, columnTotal) -> Integer.toString(count)),
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/CalculateTargetCoverage.java
@@ -48,7 +48,6 @@ import java.util.stream.IntStream;
  * <pre>
  * java -Xmx4g -jar $gatk_jar CalculateTargetCoverage \
  *   --input bam.bam \
- *   --reference ref_fasta.fa
  *   --targets padded_targets.tsv \
  *   --disableReadFilter NotDuplicateReadFilter \
  *   --output base_filename.coverage.tsv
@@ -58,7 +57,6 @@ import java.util.stream.IntStream;
  *     The interval targets are exome target intervals padded, e.g. with 250 bases on either side.
  *     Target intervals do NOT overlap. Use the PadTargets tool to generate non-overlapping padded intervals from exome targets.
  *     Do NOT use BED format. See ConvertBedToTargetFile.
- *     The reference is optional if --disableSequenceDictionaryValidation is set to true.
  * </p>
  *
  * <p>For whole genome sequencing (WGS) data, use SparkGenomeReadCounts instead.</p>


### PR DESCRIPTION

Example command is only for WES data. For WGS, I point users to SparkGenomeReadCounts.

- I nudge users to use PadTargets to pad their targets and tell them the target intervals do not overlap. I also state NOT to use BED format and point them to ConvertBedToTargetFile.
- I leave in the optional reference to safeguard newbie users. I do state that 
    ```
    The reference is optional if --disableSequenceDictionaryValidation is set to true.
    ```
- description for targets param changed to specify 1-based indexing. 
- Default params changed for:
   --groupBy SAMPLE 
   --transform PCOV 
   --targetInformationColumns FULL
