### PR TITLE
CNV NormalizeSomaticReadCounts: tag doc and provide example command

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
@@ -36,7 +36,7 @@ import java.util.List;
  * <pre>
  * java -Xmx4g -jar $gatk_jar NormalizeSomaticReadCounts \
  *   --input tumor.coverage.tsv \
- *   --targets padded_targets.tsv
+ *   --targets padded_targets.tsv \
  *   --panelOfNormals panel_of_normals.pon \
  *   --tangentNormalized tumor.tn.tsv \
  *   --preTangentNormalized tumor.preTN.tsv

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
@@ -30,11 +30,6 @@ import java.util.List;
  *
  * <h3>Examples</h3>
  * <p>
- *     The command encompasses empirically determined parameters for TCGA project data.
- *     You may obtain better results with different parameters.
- * </p>
- *
- * <p>
  *     The following command is for either whole exome sequencing (WES) or whole genome sequencing (WGS) data.
  * </p>
  *

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
@@ -36,11 +36,10 @@ import java.util.List;
  * <pre>
  * java -Xmx4g -jar $gatk_jar NormalizeSomaticReadCounts \
  *   --input tumor.coverage.tsv \
+ *   --targets padded_targets.tsv
  *   --panelOfNormals panel_of_normals.pon \
  *   --tangentNormalized tumor.tn.tsv \
- *   --factorNormalizedOutput tumor.fnt.tsv \
- *   --preTangentNormalized tumor.preTN.tsv \
- *   --betaHatsOutput tumor.betaHats.tsv
+ *   --preTangentNormalized tumor.preTN.tsv
  * </pre>
  */
 @CommandLineProgramProperties(

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.Level;
 import org.broadinstitute.barclay.argparser.*;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hdf5.HDF5File;
 import org.broadinstitute.hdf5.HDF5Library;
 import org.broadinstitute.hellbender.cmdline.*;
@@ -20,18 +21,39 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Normalizes read counts given the PanelOfNormals.
+ * Normalizes read counts given the PanelOfNormals (PoN).
  *
- * <p> Dev note:  If this is extended to use spark, please be wary that the parallelization in tangent normalization is
+ * <p> A note to developers:  If this is extended to use Spark, please be wary that the parallelization in tangent normalization is
  * by case sample, which may not yield benefits for most use cases (which are one sample)  </p>
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ *
+ * <h3>Examples</h3>
+ * <p>
+ *     The command encompasses empirically determined parameters for TCGA project data.
+ *     You may obtain better results with different parameters.
+ * </p>
+ *
+ * <p>
+ *     The following command is for either whole exome sequencing (WES) or whole genome sequencing (WGS) data.
+ * </p>
+ *
+ * <pre>
+ * java -Xmx4g -jar $gatk_jar NormalizeSomaticReadCounts \
+ *   --input coverage.tsv \
+ *   --panelOfNormals cnv_panel_of_normals.pon \
+ *   --tangentNormalized entity_id.tn.tsv \
+ *   --factorNormalizedOutput entity_id.fnt.tsv \
+ *   --preTangentNormalized entity_id.preTN.tsv \
+ *   --betaHatsOutput entity_id.betaHats.tsv
+ * </pre>
  */
 @CommandLineProgramProperties(
         summary = "Normalize PCOV read counts using a panel of normals",
         oneLineSummary = "Normalize proportional coverage (PCOV) read counts using a panel of normals",
         programGroup = CopyNumberProgramGroup.class
 )
+@DocumentedFeature
 public final class NormalizeSomaticReadCounts extends CommandLineProgram {
 
     public static final String READ_COUNTS_FILE_FULL_NAME = StandardArgumentDefinitions.INPUT_LONG_NAME;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/NormalizeSomaticReadCounts.java
@@ -35,12 +35,12 @@ import java.util.List;
  *
  * <pre>
  * java -Xmx4g -jar $gatk_jar NormalizeSomaticReadCounts \
- *   --input coverage.tsv \
- *   --panelOfNormals cnv_panel_of_normals.pon \
- *   --tangentNormalized entity_id.tn.tsv \
- *   --factorNormalizedOutput entity_id.fnt.tsv \
- *   --preTangentNormalized entity_id.preTN.tsv \
- *   --betaHatsOutput entity_id.betaHats.tsv
+ *   --input tumor.coverage.tsv \
+ *   --panelOfNormals panel_of_normals.pon \
+ *   --tangentNormalized tumor.tn.tsv \
+ *   --factorNormalizedOutput tumor.fnt.tsv \
+ *   --preTangentNormalized tumor.preTN.tsv \
+ *   --betaHatsOutput tumor.betaHats.tsv
  * </pre>
  */
 @CommandLineProgramProperties(


### PR DESCRIPTION
### Pending questions

6. For NormalizeSomaticReadCounts, in the WDL I see two additional optional output files that I've not seen before--the Fnt and betaHats:
```
*   --input coverage.tsv \
*   --panelOfNormals cnv_panel_of_normals.pon \
*   --tangentNormalized ${entity_id}.tn.tsv \
*   --factorNormalizedOutput ${entity_id}.fnt.tsv \
*   --preTangentNormalized ${entity_id}.preTN.tsv \
*   --betaHatsOutput ${entity_id}.betaHats.tsv
```
Do we now recommend these be output as well? Or shall I stick to the Vancouver demo's simplified command with just PTN and TN?

7. For NormalizeSomaticReadCounts, in contrast to the WDL, I've removed the --targets option. If I recall, this is no longer necessary because it was already applied upstream in the workflow. Is this okay?

8. For NormalizeSomaticReadCounts, there is a note to developers that could use clarification in the choice of words, e.g. "case", "sample" and "use cases":

A note to developers:  If this is extended to use Spark, please be wary that the parallelization in tangent normalization is
* by case sample, which may not yield benefits for most use cases (which are one sample)

---
### Dependent suggestion
If we will recommend all four outputs, I think NormalizeSomaticReadCounts could also use an --outputPrefix option. See AllelicCNV:

```
--outputPrefix,-pre:String    Prefix for output files. Will also be used as the sample name in downstream plots.(Note:
                              if this is a file path or contains slashes (/), the string after the final slash will be
                              used as the sample name in downstream plots.)  Required. 
```
