### PR TITLE
CNV PlotSegmentedCopyRatio: tag doc, add example command, clarify -SD parameter

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotSegmentedCopyRatio.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotSegmentedCopyRatio.java
@@ -90,7 +90,7 @@ public final class PlotSegmentedCopyRatio extends CommandLineProgram {
                     "The tool only considers contigs in the given dictionary for plotting, and " +
                     "data for contigs absent in the dictionary generate only a warning. In other words, you may " +
                     "modify a reference dictionary for use with this tool to include only contigs for which plotting is desired, " +
-                    "and sort the contigs to the order in which the plots should display the contigs."
+                    "and sort the contigs to the order in which the plots should display the contigs.",
             shortName = StandardArgumentDefinitions.SEQUENCE_DICTIONARY_SHORT_NAME,
             optional = false
     )

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotSegmentedCopyRatio.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotSegmentedCopyRatio.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
  *   --segments called_segments.seg \
  *   -SD ref_fasta_dict.dict \
  *   --output output_dir \
- *   --outputPrefix $entity_id
+ *   --outputPrefix basename
  * </pre>
  */
 @CommandLineProgramProperties(

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotSegmentedCopyRatio.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotSegmentedCopyRatio.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.CopyNumberProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -19,11 +20,31 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * Plots segmented coverage results.
+ *
+ * <p>The order of plotting follows the contig ordering within the required reference sequence dictionary. </p>
+ *
+ * <h3>Examples</h3>
+ *
+ * <p>The --output parameter specifies a directory.</p>
+ *
+ * <pre>
+ * java -Xmx4g -jar $gatk_jar PlotSegmentedCopyRatio \
+ *   --tangentNormalized tn_coverage.tn.tsv \
+ *   --preTangentNormalized pre_tn_coverage.ptn.tsv \
+ *   --segments called_segments.seg \
+ *   -SD ref_fasta_dict.dict \
+ *   --output output_dir \
+ *   --outputPrefix $entity_id
+ * </pre>
+ */
 @CommandLineProgramProperties(
         summary = "Create plots of denoised and segmented copy ratio.",
         oneLineSummary = "Create plots of denoised and segmented copy ratio",
         programGroup = CopyNumberProgramGroup.class
 )
+@DocumentedFeature
 public final class PlotSegmentedCopyRatio extends CommandLineProgram {
     private static final String CNV_PLOTTING_R_LIBRARY = "CNVPlottingLibrary.R";
     private static final String COPY_RATIO_PLOTTING_R_SCRIPT = "CopyRatioPlotting.R";
@@ -66,7 +87,8 @@ public final class PlotSegmentedCopyRatio extends CommandLineProgram {
             doc = "File containing the reference sequence dictionary (used to determine relative contig lengths). " +
                     "Contigs will be plotted in the order given. " +
                     "Contig names should not include \"" + CONTIG_DELIMITER + "\"." +
-                    "Data on contigs not in the dictionary will not be plotted and a warning will be thrown.",
+                    " Only data for contigs represented by the dictionary will be plotted. " +
+                    "Data for contigs absent in the dictionary generate a warning.",
             shortName = StandardArgumentDefinitions.SEQUENCE_DICTIONARY_SHORT_NAME,
             optional = false
     )

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotSegmentedCopyRatio.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/plotting/PlotSegmentedCopyRatio.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 /**
  * Plots segmented coverage results.
  *
- * <p>The order of plotting follows the contig ordering within the required reference sequence dictionary. </p>
+ * <p>The order and representation of contigs in plots follows the contig ordering within the required reference sequence dictionary. </p>
  *
  * <h3>Examples</h3>
  *
@@ -86,9 +86,11 @@ public final class PlotSegmentedCopyRatio extends CommandLineProgram {
     @Argument(
             doc = "File containing the reference sequence dictionary (used to determine relative contig lengths). " +
                     "Contigs will be plotted in the order given. " +
-                    "Contig names should not include \"" + CONTIG_DELIMITER + "\"." +
-                    " Only data for contigs represented by the dictionary will be plotted. " +
-                    "Data for contigs absent in the dictionary generate a warning.",
+                    "Contig names should not include the string \"" + CONTIG_DELIMITER + "\". " +
+                    "The tool only considers contigs in the given dictionary for plotting, and " +
+                    "data for contigs absent in the dictionary generate only a warning. In other words, you may " +
+                    "modify a reference dictionary for use with this tool to include only contigs for which plotting is desired, " +
+                    "and sort the contigs to the order in which the plots should display the contigs."
             shortName = StandardArgumentDefinitions.SEQUENCE_DICTIONARY_SHORT_NAME,
             optional = false
     )


### PR DESCRIPTION
### Pending questions
For PlotSegmentedCopyRatio, what are the "CONTIG_DELIMITER"s? The --sequenceDictionaryFile parameter mentions that contig names should not have these but doesn't define what these are:

```
--sequenceDictionaryFile,-SD:File

                              File containing the reference sequence dictionary (used to determine relative contig

                              lengths). Contigs will be plotted in the order given. Contig names should not include

                              "CONTIG_DELIMITER".Data on contigs not in the dictionary will not be plotted and warning

                              will be thrown.  Required. 
```