### PR TITLE
CNV ConvertACNVResults: tag doc, give example command, question summary

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResults.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResults.java
@@ -5,6 +5,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.ExomeStandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.CopyNumberProgramGroup;
 import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
@@ -19,16 +20,30 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Convert AllelicCNV results to TITAN and Allelic CapSeg formats.
+ *
+ * <h3>Example</h3>
+ *
+ * <pre>
+ * java -Xmx4g -jar $gatk_jar ConvertACNVResults \
+ *   --tumorHets hets.het \
+ *   --tangentNormalized tn_coverage.tn.tsv \
+ *   --segments acnv_segments.seg \
+ *   --outputDir output_dir
+ * </pre>
+ */
 @CommandLineProgramProperties(
 
         summary = "Convert files into TITAN and " +
-                "Broad CGA Allelic CapSeg (ACS) formats.  This tool uses spark, though running locally is fine.\n" +
-                "As part of this process, this tool generates calls whether a particular segment is balanced (MAF=0.5)" +
-                "\nIMPORTANT:  The additional CNLoH calls from this tool should be treated with a lot of skepticism.  Preliminary results " +
-                "indicated very poor performance.",
-        oneLineSummary = "Convert ACNV results to Broad CGA Allelic CapSeg (ACS) and TITAN files.",
+                "Broad CGA Allelic CapSeg (ACS) formats.  This tool uses Spark, though running locally is fine.\n" +
+                "As a part of this process, the tool calls whether a particular segment is balanced (MAF or minor allele frequency of 0.5)." +
+                "\nNOTE: Treat the additional CNLoH (Copy-Neutral Loss of Heterozygosity) calls with skepticism, as preliminary results " +
+                "using TCGA data have shown a high rate of false-positive calls.",
+        oneLineSummary = "Convert AllelicCNV (ACNV) results to Broad CGA Allelic CapSeg (ACS) and TITAN files.",
         programGroup = CopyNumberProgramGroup.class
 )
+@DocumentedFeature
 public class ConvertACNVResults extends SparkCommandLineProgram {
 
     static final long serialVersionUID = 42123132L;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResults.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResults.java
@@ -39,8 +39,8 @@ import java.util.List;
                 "Broad CGA Allelic CapSeg (ACS) formats.  This tool uses Spark, though running locally is fine.\n" +
                 "As a part of this process, the tool calls whether a particular segment is balanced (MAF or minor allele frequency of 0.5)." +
                 "\nNOTE: Treat the additional CNLoH (Copy-Neutral Loss of Heterozygosity) calls with skepticism, as preliminary results " +
-                "using TCGA data have shown a high rate of false-positive calls.",
-        oneLineSummary = "Convert AllelicCNV (ACNV) results to Broad CGA Allelic CapSeg (ACS) and TITAN files.",
+                "using TCGA data have shown a high error rate, i.e. high rates of both false-positive and false-negative calls.",
+        oneLineSummary = "(Experimental) Convert AllelicCNV (ACNV) results to Broad CGA Allelic CapSeg (ACS) and TITAN files.",
         programGroup = CopyNumberProgramGroup.class
 )
 @DocumentedFeature

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResults.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/ConvertACNVResults.java
@@ -27,16 +27,18 @@ import java.util.List;
  *
  * <pre>
  * java -Xmx4g -jar $gatk_jar ConvertACNVResults \
- *   --tumorHets hets.het \
+ *   --tumorHets heterozygous_coverage.het \
  *   --tangentNormalized tn_coverage.tn.tsv \
  *   --segments acnv_segments.seg \
- *   --outputDir output_dir
+ *   --outputDir output_folder
  * </pre>
+ *
+ * <p>The tool runs locally by default. Use the --sparkMaster option to enable Spark.</p>
  */
 @CommandLineProgramProperties(
 
         summary = "Convert files into TITAN and " +
-                "Broad CGA Allelic CapSeg (ACS) formats.  This tool uses Spark, though running locally is fine.\n" +
+                "Broad CGA Allelic CapSeg (ACS) formats.  This tool can use Spark if enabled.\n" +
                 "As a part of this process, the tool calls whether a particular segment is balanced (MAF or minor allele frequency of 0.5)." +
                 "\nNOTE: Treat the additional CNLoH (Copy-Neutral Loss of Heterozygosity) calls with skepticism, as preliminary results " +
                 "using TCGA data have shown a high error rate, i.e. high rates of both false-positive and false-negative calls.",


### PR DESCRIPTION
### Pending questions

ConvertACNVResults original summary blurb:

```
Convert files into TITAN and Broad CGA Allelic CapSeg (ACS) formats.  This tool uses spark, though running locally is fine.
As part of this process, this tool generates calls whether a particular segment is balanced (MAF=0.5)
IMPORTANT:  The additional CNLoH calls from this tool should be treated with a lot of skepticism.  Preliminary results indicated very poor performance.
```

- Eventually we will need a description and example of the TITAN format.
- Eventually we will need a description and example of Broad CGA Allelic CapSeg (ACS) format.
- "This tool uses spark, though running locally is fine." Is using Spark the default? What parameters are involved to use or not use Spark (e.g. --sparkMaster)? Can I instead say "To enable Spark, use the --sparkMaster option."?
- If the CNLoH calls need to be treated with a lot of skepticism and results indicate very poor performance, then shouldn't this tool be under the experimental category? Otherwise, if the tool has improved since this blurb was written, shall we remove this notice? 
- What does "poor performance" mean? Unreliable or false? Can we instead say something along the lines of "Treat the additional CNLoH (Copy-Neutral Loss of Heterozygosity) calls with skepticism, as preliminary results using TCGA data have shown a high rate of false-positive calls." Or high rate of false-negative calls, etc.
