### PR TITLE
CNV CorrectGCBias: Shl doc correct gc bias

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/AnnotateTargets.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/AnnotateTargets.java
@@ -55,7 +55,7 @@ import java.util.Map;
  * java -Xmx4g -jar $gatk_jar AnnotateTargets \
  *   --targets targets.tsv \
  *   --reference ref_fasta.fa \
- *   --output entity_id.annotated.tsv
+ *   --output targets.annotated.tsv
  * </pre>
  *
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/eval/ConvertGSVariantsToSegments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/eval/ConvertGSVariantsToSegments.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang.math.IntRange;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.CopyNumberProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -33,15 +34,51 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * Tool to convert Genotype Strip Variant call file into {@link HiddenStateSegmentRecord} table file.
+ * Converts Genome STRiP (GS) variant call format (VCF) variants into {@link HiddenStateSegmentRecord} CopyNumberTriState format calls.
  *
+ * <p>
+ *     CopyNumberTriState refers to the three copy number calls of plus (+), neutral (0) and minus (-).
+ *     Use the resulting file with {@link EvaluateCopyNumberTriStateCalls}.
+ *     Here are example CopyNumberTriState format calls:
+ * </p>
+ *
+ * <pre>
+ *     Sample  Chromosome      Start   End     Segment_Call    Num_Targets     Segment_Mean    Segment_Std     Exact_Quality   Some_Quality    Start_Quality   End_Quality     Event_Quality
+ *     01C05110        1       21944797        21946084        0       1       2.3443  0.0000  44.4002 NaN     NaN     NaN     0.0000
+ *     01C06980        1       21944797        21946084        0       1       2.2533  0.0000  59.8000 NaN     NaN     NaN     0.0000
+ *     01C07132        1       21944797        21946084        0       1       2.1878  0.0000  68.7000 NaN     NaN     NaN     0.0000
+ *     01C07215        1       21944797        21946084        0       1       1.6267  0.0000  96.5991 NaN     NaN     NaN     0.0000
+ *     01C07248        1       21944797        21946084        0       1       1.7863  0.0000  103.2934        NaN     NaN     NaN     0.0000
+ *     01C07286        1       21944797        21946084        0       1       2.1658  0.0000  68.7000 NaN     NaN     NaN     0.0000
+ *     01C07431        1       21944797        21946084        0       1       2.1904  0.0000  66.1000 NaN     NaN     NaN     0.0000
+ *     01C07450        1       21944797        21946084        0       1       2.1317  0.0000  75.0000 NaN     NaN     NaN     0.0000
+ *     01C05110        1       46597740        46598439        0       0       2.2678  0.0000  34.2017 NaN     NaN     NaN     0.0000
+ *     01C06980        1       46597740        46598439        0       0       2.0544  0.0000  49.5000 NaN     NaN     NaN     0.0000
+ *     01C07132        1       46597740        46598439        +       0       2.7620  0.0000  5.3133  NaN     NaN     NaN     5.3000
+ *     01C07215        1       46597740        46598439        0       0       2.5568  0.0000  13.6898 NaN     NaN     NaN     0.2000
+ * </pre>
+ *
+ * <h3>Example</h3>
+ *
+ * <pre>
+ * java -jar $gatk_jar ConvertGSVariantsToSegments
+ *   --variant genomestrip.vcf.gz
+ *   --output copynumbertristate.seg
+ * </pre>
+ *
+ * <p>
+ *     Optional argument --targets (see {@link org.broadinstitute.hellbender.tools.exome.convertbed.ConvertBedToTargetFile})
+ *     limits data to the listed target intervals.
+ * </p>
+ * 
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
 @CommandLineProgramProperties(
         summary = "Convert Genome STRiP VCF file contents into a CopyNumberTriState segment file. Genome STRiP can be found at http://www.broadinstitute.org/software/genomestrip",
-        oneLineSummary = "Convert Genome STRiP VCF file into a segment file",
+        oneLineSummary = "(Internal) Convert Genome STRiP VCF file into a segment file",
         programGroup = CopyNumberProgramGroup.class
 )
+@DocumentedFeature
 public final class ConvertGSVariantsToSegments extends VariantWalker {
 
     public static final String OUTPUT_FILE_SHORT_NAME = StandardArgumentDefinitions.OUTPUT_SHORT_NAME;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/eval/ConvertGSVariantsToSegments.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/eval/ConvertGSVariantsToSegments.java
@@ -7,7 +7,6 @@ import org.apache.commons.lang.math.IntRange;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
-import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.CopyNumberProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -34,51 +33,15 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * Converts Genome STRiP (GS) variant call format (VCF) variants into {@link HiddenStateSegmentRecord} CopyNumberTriState format calls.
+ * Tool to convert Genotype Strip Variant call file into {@link HiddenStateSegmentRecord} table file.
  *
- * <p>
- *     CopyNumberTriState refers to the three copy number calls of plus (+), neutral (0) and minus (-).
- *     Use the resulting file with {@link EvaluateCopyNumberTriStateCalls}.
- *     Here are example CopyNumberTriState format calls:
- * </p>
- *
- * <pre>
- *     Sample  Chromosome      Start   End     Segment_Call    Num_Targets     Segment_Mean    Segment_Std     Exact_Quality   Some_Quality    Start_Quality   End_Quality     Event_Quality
- *     01C05110        1       21944797        21946084        0       1       2.3443  0.0000  44.4002 NaN     NaN     NaN     0.0000
- *     01C06980        1       21944797        21946084        0       1       2.2533  0.0000  59.8000 NaN     NaN     NaN     0.0000
- *     01C07132        1       21944797        21946084        0       1       2.1878  0.0000  68.7000 NaN     NaN     NaN     0.0000
- *     01C07215        1       21944797        21946084        0       1       1.6267  0.0000  96.5991 NaN     NaN     NaN     0.0000
- *     01C07248        1       21944797        21946084        0       1       1.7863  0.0000  103.2934        NaN     NaN     NaN     0.0000
- *     01C07286        1       21944797        21946084        0       1       2.1658  0.0000  68.7000 NaN     NaN     NaN     0.0000
- *     01C07431        1       21944797        21946084        0       1       2.1904  0.0000  66.1000 NaN     NaN     NaN     0.0000
- *     01C07450        1       21944797        21946084        0       1       2.1317  0.0000  75.0000 NaN     NaN     NaN     0.0000
- *     01C05110        1       46597740        46598439        0       0       2.2678  0.0000  34.2017 NaN     NaN     NaN     0.0000
- *     01C06980        1       46597740        46598439        0       0       2.0544  0.0000  49.5000 NaN     NaN     NaN     0.0000
- *     01C07132        1       46597740        46598439        +       0       2.7620  0.0000  5.3133  NaN     NaN     NaN     5.3000
- *     01C07215        1       46597740        46598439        0       0       2.5568  0.0000  13.6898 NaN     NaN     NaN     0.2000
- * </pre>
- *
- * <h3>Example</h3>
- *
- * <pre>
- * java -jar $gatk_jar ConvertGSVariantsToSegments
- *   --variant genomestrip.vcf.gz
- *   --output copynumbertristate.seg
- * </pre>
- *
- * <p>
- *     Optional argument --targets (see {@link org.broadinstitute.hellbender.tools.exome.convertbed.ConvertBedToTargetFile})
- *     limits data to the listed target intervals.
- * </p>
- * 
  * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
  */
 @CommandLineProgramProperties(
         summary = "Convert Genome STRiP VCF file contents into a CopyNumberTriState segment file. Genome STRiP can be found at http://www.broadinstitute.org/software/genomestrip",
-        oneLineSummary = "(Internal) Convert Genome STRiP VCF file into a segment file",
+        oneLineSummary = "Convert Genome STRiP VCF file into a segment file",
         programGroup = CopyNumberProgramGroup.class
 )
-@DocumentedFeature
 public final class ConvertGSVariantsToSegments extends VariantWalker {
 
     public static final String OUTPUT_FILE_SHORT_NAME = StandardArgumentDefinitions.OUTPUT_SHORT_NAME;

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/gcbias/CorrectGCBias.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/gcbias/CorrectGCBias.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
  * 2. targets file containing GC content annotation as produced by {@link AnnotateTargets}.  Every target in the input
  *    read counts must be present in the targets file but the reverse need not be true.
  *
- * The resulting read counts file has the same targets (rows) and samples (columns) as the input and GC-bias-corrected coverage.
+ * The resulting read counts file has the same targets (rows) and samples (columns) as the input, with entries denoting GC-bias-corrected coverage.
  * Coverage is represented by doubles in {@link ReadCountCollection}.
  * </p>
  *
@@ -42,9 +42,9 @@ import java.util.stream.Collectors;
  * @author David Benjamin &lt;davidben@broadinstitute.org&gt;
  */
 @CommandLineProgramProperties(
-        oneLineSummary = "Correct for per-target GC bias effects",
-        summary = "Correct coverage in read counts by estimating per-sample bias as a function of per-target GC " +
-                "content and by dividing input coverage by derived bias curves.",
+        oneLineSummary = "Correct for sample-specific GC bias",
+        summary = "Correct coverage in read counts by (i) estimating per-sample bias as a function of per-target GC " +
+                "content and (ii) dividing input coverage by derived bias curves.",
         programGroup = CopyNumberProgramGroup.class
 )
 @DocumentedFeature

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/gcbias/CorrectGCBias.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/gcbias/CorrectGCBias.java
@@ -4,6 +4,7 @@ import org.broadinstitute.barclay.argparser.*;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.ArgumentCollection;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.CopyNumberProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 /**
  * Correct coverage for sample-specific GC bias effects as described in {@link GCCorrector}.
  *
+ * <p>
  * Inputs are
  * 1. read counts file (format described in {@link ReadCountCollectionUtils}).  Since this tool corrects
  *    for multiplicative GC bias effects, these counts should not be in log space i.e. they should represent
@@ -24,17 +26,28 @@ import java.util.stream.Collectors;
  * 2. targets file containing GC content annotation as produced by {@link AnnotateTargets}.  Every target in the input
  *    read counts must be present in the targets file but the reverse need not be true.
  *
- * Output is a read counts file with the same targets (rows) and samples (columns) as the input, corrected for GC bias.
+ * The resulting read counts file has the same targets (rows) and samples (columns) as the input and GC-bias-corrected coverage.
  * Coverage is represented by doubles in {@link ReadCountCollection}.
+ * </p>
+ *
+ * <h3>Example</h3>
+ *
+ * <pre>
+ * java -Xmx4g -jar $gatk_jar CorrectGCBias \
+ *   --input coverage.tsv \
+ *   --targets targets.annotated.tsv \
+ *   --output coverage.gc_corrected.tsv
+ * </pre>
  *
  * @author David Benjamin &lt;davidben@broadinstitute.org&gt;
  */
 @CommandLineProgramProperties(
-        oneLineSummary = "Correct for per-sample GC bias effects",
-        summary = "Correct coverage in a read counts files by estimating per-sample bias as a function of target GC" +
-                " content and dividing input coverage by these derived bias curves.",
+        oneLineSummary = "Correct for per-target GC bias effects",
+        summary = "Correct coverage in read counts by estimating per-sample bias as a function of per-target GC " +
+                "content and by dividing input coverage by derived bias curves.",
         programGroup = CopyNumberProgramGroup.class
 )
+@DocumentedFeature
 public class CorrectGCBias extends CommandLineProgram {
     public static final String INPUT_READ_COUNTS_FILE_LONG_NAME = StandardArgumentDefinitions.INPUT_LONG_NAME;
     public static final String INPUT_READ_COUNTS_FILE_SHORT_NAME = StandardArgumentDefinitions.INPUT_SHORT_NAME;


### PR DESCRIPTION
- Besides the usual doc changes, updated the following:
```

        oneLineSummary = "Correct for per-sample GC bias effects",
        summary = "Correct coverage in read counts by estimating per-sample bias as a function of target GC " +
                "content and dividing input coverage by these derived bias curves.",
```

to refer to _per-target_ instead of per-sample.

- In addition, updated the output name of `AnnotateTargets.java` to match the input of CorrectGCBias: targets.annotated.tsv 
