### PR TITLE
Other tools: tag docs, label internal, add minimal formatting

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/AnnotateVcfWithBamDepth.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/AnnotateVcfWithBamDepth.java
@@ -7,6 +7,7 @@ import htsjdk.variant.vcf.*;
 import org.apache.commons.lang.mutable.MutableInt;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -26,21 +27,30 @@ import java.util.Set;
  * Annotate every variant in a VCF with the depth at that locus in a bam.  Note that this bam is *not* the bam
  * from which the vcf was derived, otherwise we would simply use the DP INFO field.
  *
+ * <p>
  * In the CRSP sensitivity validation, we have a bam derived from a pool of 5, 10, or 20 samples
  * and a vcf of all known variants in those samples.  The pooled bam is a simulated tumor and
  * the vcf of individual variants is our truth data.  We annotate the truth data with the depth
  * in the pooled bam in order to bin the results of our sensitivity analysis by depth.
+ * </p>
  *
- *  * Example usage:
- * java -jat gatk.jar AnnotateVcfWithBamDepth -V input.vcf -I reads.bam -O output.vcf
+ * <h3>Example</h3>
+ *
+ * <pre>
+ * java -jar gatk.jar AnnotateVcfWithBamDepth \
+ *   -V input.vcf \
+ *   -I reads.bam \
+ *   -O output.vcf
+ * </pre>
  *
  * Created by David Benjamin on 1/30/17.
  */
 @CommandLineProgramProperties(
         summary = "Annotate a vcf with a bam's read depth at each variant locus",
-        oneLineSummary = "Annotate a vcf with a bam's read depth at each variant locus",
+        oneLineSummary = "(Internal) Annotate a vcf with a bam's read depth at each variant locus",
         programGroup = VariantProgramGroup.class
 )
+@DocumentedFeature
 public class AnnotateVcfWithBamDepth extends VariantWalker {
 
     @Argument(fullName= StandardArgumentDefinitions.OUTPUT_LONG_NAME,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/AnnotateVcfWithExpectedAlleleFraction.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/AnnotateVcfWithExpectedAlleleFraction.java
@@ -11,6 +11,7 @@ import htsjdk.variant.vcf.VCFInfoHeaderLine;
 import org.apache.commons.math3.util.MathArrays;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -28,12 +29,22 @@ import java.util.stream.Collectors;
 
 /**
  * Given mixing weights of different samples in a pooled bam, annotate a corresponding
- * vcf containing individual sample genotypes.  The formula is:
+ * vcf containing individual sample genotypes.
  *
- * Expected allele fraction = SUM_samples {mixing_fraction(sample) * [0 if hom ref, 0.5 is het, 1.0 if hom var]}
+ * <p>The formula is:</p>
  *
- * Usage:
- * java -jar gatk.jar AnnotateVcfWithExpectedAlleleFraction -V input.vcf -O output.vcf -mixingFractions mixingFractions.table
+ * <p>
+ *     Expected allele fraction = SUM_samples {mixing_fraction(sample) * [0 if hom ref, 0.5 is het, 1.0 if hom var]}
+ * </p>
+ *
+ * <h3>Example</h3>
+ *
+ * <pre>
+ * java -jar gatk.jar AnnotateVcfWithExpectedAlleleFraction \
+ *   -V input.vcf \
+ *   -O output.vcf \
+ *   -mixingFractions mixingFractions.table
+ * </pre>
  *
  * Created by David Benjamin on 1/31/17.
  */
@@ -41,9 +52,10 @@ import java.util.stream.Collectors;
         summary = "Annotate a multi-sample vcf with expected allele fractions in pooled sequencing given mixing" +
                 " fractions of the different samples in the pool via the formula" +
                 " Expected allele fraction = SUM_samples {mixing_fraction(sample) * [0 if hom ref, 0.5 is het, 1.0 if hom var]}",
-        oneLineSummary = "Annotate a vcf with expected allele fractions in pooled sequencing",
+        oneLineSummary = "(Internal) Annotate a vcf with expected allele fractions in pooled sequencing",
         programGroup = VariantProgramGroup.class
 )
+@DocumentedFeature
 public class AnnotateVcfWithExpectedAlleleFraction extends VariantWalker {
 
     public static final String MIXING_FRACTIONS_TABLE_NAME = "mixingFractions";

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/CalculateMixingFractions.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/CalculateMixingFractions.java
@@ -5,6 +5,7 @@ import htsjdk.variant.vcf.*;
 import org.apache.commons.lang.mutable.MutableLong;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.*;
@@ -24,17 +25,26 @@ import java.util.stream.StreamSupport;
  * contributes to a pooled BAM.  We first estimate each sample's mixing fraction as the average alt fraction
  * in the bam of singleton hets belonging to that sample, then normalize these initial estimates to sum to one.
  *
+ * <p>
  * In the CRSP sensitivity validation, we have a bam derived from a pool of 5, 10, or 20 samples
  * and a vcf of all known variants in those samples.  The pooled bam is a simulated tumor and
  * the vcf of individual variants is our truth data.  We annotate the truth data with the estimated
  * allele fractions of each variant in the pooled bam in order to bin our results by "tumor" allele fraction.
  * To estimate allele fractions we need to know the sample mixing fractions as an intermediate step.
+ * </p>
  *
+ * <p>
  * One could use this tool for generating precise truth data any time multiple samples with known ground
  * truth are combined to simulate tumors or any situation in which low allele fractions occur.
+ * </p>
  *
- * Example usage:
- * java -jat gatk.jar CalculateMixingFractions -V input.vcf -O output.table
+ * <h3>Example</h3>
+ *
+ * <pre>
+ * java -jat gatk.jar CalculateMixingFractions \
+ *   -V input.vcf \
+ *   -O output.table
+ * </pre>
  *
  * Created by David Benjamin on 1/30/17.
  */
@@ -42,9 +52,10 @@ import java.util.stream.StreamSupport;
         summary = "Calculate proportions of different samples in a pooled bam by first estimating each sample's" +
                 " mixing fraction as the average alt fraction in the bam of singleton hets belonging to that sample, then" +
                 " normalizing these initial estimates to sum to one.",
-        oneLineSummary = "Calculate proportions of different samples in a pooled bam",
+        oneLineSummary = "(Internal) Calculate proportions of different samples in a pooled bam",
         programGroup = VariantProgramGroup.class
 )
+@DocumentedFeature
 public class CalculateMixingFractions extends VariantWalker {
 
     @Argument(fullName= StandardArgumentDefinitions.OUTPUT_LONG_NAME,

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/RemoveNearbyIndels.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/validation/RemoveNearbyIndels.java
@@ -5,6 +5,7 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.help.DocumentedFeature;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
@@ -17,20 +18,30 @@ import java.io.File;
 import java.util.ArrayDeque;
 
 /**
- * Remove indels that are close to another indel from a vcf.  This is a preprocessing step
- * for the CRSP sensitivity validation truth data.
+ * Remove indels that are close to another indel from a vcf.
  *
- * Example usage:
- * java -jat gatk.jar RemoveNearbyIndels -V input.vcf -O output.vcf -minIndelSpacing 20
+ * <p>
+ * This is a preprocessing step for the CRSP sensitivity validation truth data.
+ * </p>
+ *
+ * <h3>Example</h3>
+ *
+ * <pre>
+ * java -jat gatk.jar RemoveNearbyIndels \
+ *   -V input.vcf \
+ *   -O output.vcf \
+ *   -minIndelSpacing 20
+ * </pre>
  *
  * Created by David Benjamin on 1/30/17.
  */
 @CommandLineProgramProperties(
         summary = "Remove indels that are close to each other from a vcf.  For any pair of indels that are within" +
                 "some minimum allowed distance, both indels are removed, regardless of any intervening non-indel variants.",
-        oneLineSummary = "Remove indels that are close to each other from a vcf",
+        oneLineSummary = "(Internal) Remove indels that are close to each other from a vcf",
         programGroup = VariantProgramGroup.class
 )
+@DocumentedFeature
 public class RemoveNearbyIndels extends VariantWalker {
 
     public static final String MIN_INDEL_SPACING_NAME = "minIndelSpacing";


### PR DESCRIPTION
Tagged and labeled 'internal' the following four tools:

- AnnotateVcfWithBamDepth
- AnnotateVcfWithExpectedAlleleFraction
- CalculateMixingFractions
- RemoveNearbyIndels

Other than some formatting changes, did not change other content.